### PR TITLE
Remove empty headers in back hints and back solutions

### DIFF
--- a/book/additional-topics/order-relations.tex
+++ b/book/additional-topics/order-relations.tex
@@ -1,6 +1,6 @@
 % !TeX root = ../../infdesc.tex
 \section{Orders and lattices}
-\label{secOrderRelations}
+\secbegin{secOrderRelations}
 \label{secPosets}
 \label{secOrdersLattices}
 

--- a/book/additional-topics/structural-induction.tex
+++ b/book/additional-topics/structural-induction.tex
@@ -1,6 +1,6 @@
 % !TeX root = ../../infdesc.tex
 \section{Inductively defined sets}
-\label{secStructuralInduction}
+\secbegin{secStructuralInduction}
 \index{induction!structural|(}
 
 In \Cref{secPeanosAxioms}, we formalised the idea that the set of natural numbers should be what is obtained by starting with zero and repeating the successor (`plus one') operation---this was done using Peano's axioms (\Cref{defNotionOfNaturalNumbers}). From these axioms we were able to derive the weak and strong induction principles, which turned out to be extremely powerful for proving results about natural numbers.

--- a/book/hints-solutions/_hints-solutions.tex
+++ b/book/hints-solutions/_hints-solutions.tex
@@ -9,10 +9,12 @@
 \section{Hints for selected exercises}
 \label{secHints}
 
+\flushhints
 \printhints
 
 \newpage
 \section{Solutions to in-chapter exercises}
 \label{secSolutions}
 
+\flushsolutions
 \printsolutions

--- a/book/includes/packages.tex
+++ b/book/includes/packages.tex
@@ -62,6 +62,8 @@
 \usepackage{type1cm}
 \usepackage[normalem]{ulem}
 \usepackage{xcolor}
+\usepackage{etoolbox}
+\usepackage{ifthen}
 \usepackage{xpatch}
 
 % Packages that are fussy about what order they're put in

--- a/book/includes/theorems.tex
+++ b/book/includes/theorems.tex
@@ -357,17 +357,52 @@
   \immediate\openout\solutionsfile=\jobname-solutions.cll
 }
 
+% Buffer for hints and exercises
+\gdef\sectionbackhints{}
+\gdef\sectionbacksolutions{}
+\gdef\backhintssectionname{}
+\gdef\backsolutionssectionname{}
+
+\newbool{sechasbackhints}
+\newbool{sechasbacksolutions}
+
 \NewEnviron{backhint}{
-  \immediate\write\hintsfile{%
+  \global\booltrue{sechasbackhints}
+  \xdef\sectionbackhints{%
+    \unexpanded\expandafter{\sectionbackhints}^^J%
     \expandafter\unexpanded\expandafter{\BODY}^^J%
   }%
 }
 
 \NewEnviron{backsolution}{
-  \immediate\write\solutionsfile{%
+  \global\booltrue{sechasbacksolutions}
+  \xdef\sectionbacksolutions{%
+    \unexpanded\expandafter{\sectionbacksolutions}^^J%
     \expandafter\unexpanded\expandafter{\BODY}^^J%
   }%
 }
+
+\newcommand{\flushhints}{%
+  \ifbool{sechasbackhints}{%
+  \immediate\write\hintsfile{%
+    \expandafter\unexpanded\expandafter{\backhintssectionname}^^J%
+    \expandafter\unexpanded\expandafter{\sectionbackhints}%
+  }%
+  \gdef\sectionbackhints{}}{}%
+  \global\boolfalse{sechasbackhints}
+}
+
+
+\newcommand{\flushsolutions}{%
+  \ifbool{sechasbacksolutions}{%
+  \immediate\write\solutionsfile{%
+    \expandafter\unexpanded\expandafter{\backsolutionssectionname}^^J%
+    \expandafter\unexpanded\expandafter{\sectionbacksolutions}%
+  }%
+  \gdef\sectionbacksolutions{}}{}%
+  \global\boolfalse{sechasbacksolutions}
+}
+
 
 \newcommand{\printhints}{%
   % Closing the file
@@ -396,13 +431,11 @@
 }
 
 \newcommand{\hintsection}[1]{%
-\begin{backhint}
-\subsection*{#1}
-\end{backhint}%
+\flushhints%
+\gdef\backhintssectionname{\subsection*{#1}}
 }
 
 \newcommand{\solutionsection}[1]{%
-\begin{backsolution}
-\subsection*{#1}
-\end{backsolution}%
+\flushsolutions%
+\gdef\backsolutionssectionname{\subsection*{#1}}
 }


### PR DESCRIPTION
This PR changes the way that the hints and solutions in the back are stored and put into the document. In short it does the following:

- It stores the hints, solutions and section headings in separate command sequences
- It uses an `etoolbox` boolean to track whether a section contains hints a/o solutions
- At the start of the next section it writes the hints and solutions to the hints/solutions file if necessary

To ensure that the last section also can have hints and solutions, the hints and solutions are flushed once more to the disk before inputting this auxiliary files into the document.

Additionally, two section begin macros are added to the last chapter as these were missing there.