### PR TITLE
Add \plan and \chplan commands with sub-parts support

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,3 @@
+I want the .tex files to be updated with the \plan and \chplan command, such that compiling the document and running the python script results in semantically the same planning as targetplanning.csv.
+
+Inspect this repository and extend this plan to include the detailed steps to achieve this.

--- a/book/finite-infinite-sets/finite-sets.tex
+++ b/book/finite-infinite-sets/finite-sets.tex
@@ -45,6 +45,7 @@ The function $f$ is evidently a bijection, since each element of $X$ can be expr
 \end{example}
 
 \begin{exercise}
+\plan{7.1}{Essentieel}
 \label{exBracketNIsFinite}
 Prove that $[n]$ is finite for each $n \in \mathbb{N}$.
 \solution{exBracketNIsFinite}{%
@@ -123,6 +124,7 @@ The result now follows by induction.
 \end{cproof}
 
 \begin{exercise}
+\plan{7.1}{Aanbevolen}
 Prove parts (b) and (c) of \Cref{thmJectionsAndSizeOfNaturalNumbers}.
 \hintlabel{exFinishProofOfJectionsAndSizeOfNaturalNumbers}{%
 Part (b) has a proof by induction that looks much like the one in part (a). In the induction step, given a surjection $g : [m+1] \to [n]$, observe that we must have $n \ge 1$, and construct a surjection $g^- : [m+1] \setminus \{ a \} \to [n-1]$ for some suitable $a \in [m+1]$. Then invoke \Cref{lemRemoveElementFromSet}, now using the fact that $[m] = [m+1] \setminus \{m+1\}$.
@@ -172,6 +174,7 @@ Since $f$ is a bijection, we have $|X| = 2n+1$ by \Cref{defSize}.
 \end{example}
 
 \begin{exercise}
+\plan{7.1}{Essentieel}
 \label{exAddRemoveElementsOfFiniteSets}
 Let $X$ be a finite set.
 \begin{enumerate}[(a)]
@@ -222,6 +225,7 @@ The result now follows by induction.
 \end{cproof}
 
 \begin{exercise}
+\plan{7.1}{Aanbevolen}
 Prove parts (b) and (c) of \Cref{thmFiniteSetsAndJections}.
 \end{exercise}
 
@@ -244,6 +248,7 @@ Strategy \ref{strBijectiveProof} is commonly known as \textbf{bijective proof}.
 We now use \Cref{strComparingSizesOfFiniteSets} to prove some \textit{closure properties} of finite sets---that is, operations we can perform on finite sets to ensure that the result remains finite.
 
 \begin{exercise}
+\plan{7.1}{Essentieel}
 Let $X$ be a finite set. Prove that every subset $A \subseteq X$ is finite and $|A| \le |X|$.
 \hintlabel{exSubsetOfFiniteSetIsFinite}{%
 Given $A \subseteq X$, find an injection $A \to X$ and apply \Cref{thmFiniteSetsAndJections}\ref{itmFiniteSetFromInjection}.
@@ -254,6 +259,7 @@ Let $i : A \to X$ be the \textit{inclusion function}, defined by $i(x)=x$ for al
 \end{exercise}
 
 \begin{exercise}
+\plan{7.1}{Essentieel}
 Let $X$ and $Y$ be finite sets. Prove that $X \cap Y$ is finite.
 \hintlabel{exIntersectionOfFiniteSetsIsFinite}{%
 Recall that $X \cap Y \subseteq X$ for all sets $X$ and $Y$.
@@ -283,6 +289,7 @@ Hence $|X \cup Y| = m+n = |X| + |Y|$, which is as required since $|X \cap Y| = 0
 \end{cproof}
 
 \begin{exercise}
+\plan{7.1}{Aanbevolen}
 \label{exSizeOfUnion}
 The following steps complete the proof of \Cref{propUnionOfFiniteSetsIsFinite}:
 \begin{enumerate}[(a)]
@@ -297,6 +304,7 @@ The following steps complete the proof of \Cref{propUnionOfFiniteSetsIsFinite}:
 \end{exercise}
 
 \begin{exercise}
+\plan{7.1}{Essentieel}
 Let $X$ be a finite set and let $U \subseteq X$. Prove that $X \setminus U$ is finite, and moreover $|X \setminus U| = |X| - |U|$. How does this result change if $U$ is not required to be a subset of $X$?
 \hintlabel{exSizeOfRelativeComplement}{%
 Apply \Cref{propUnionOfFiniteSetsIsFinite} with $Y=U$.
@@ -304,6 +312,7 @@ Apply \Cref{propUnionOfFiniteSetsIsFinite} with $Y=U$.
 \end{exercise}
 
 \begin{exercise}
+\plan{7.1}{Aanbevolen}
 \label{exSizeOfCartesianProduct}
 Let $m,n \in \mathbb{N}$. Prove that $|[m] \times [n]| = mn$.
 \hintlabel{exBijectionBetweenProductOfBracketSets}{%

--- a/book/finite-infinite-sets/infinite-sets.tex
+++ b/book/finite-infinite-sets/infinite-sets.tex
@@ -52,11 +52,13 @@ which is exactly the list we presented earlier! The fact that $f$ is a bijection
 \end{example}
 
 \begin{exercise}
+\plan{7.1}{Aanbevolen}
 \label{exPositiveIntegersCountablyInfinite}
 Prove that the set of all positive integers is countably infinite.
 \end{exercise}
 
 \begin{exercise}
+\plan{7.1}{Essentieel}
 \label{exEvenOddNaturalNumbersCountablyInfinite}
 Prove that the set of all even natural numbers is countably infinite, and that the set of all odd natural numbers is countably infinite.
 \end{exercise}
@@ -64,6 +66,7 @@ Prove that the set of all even natural numbers is countably infinite, and that t
 Since the inverse of a bijection is a bijection, we may also prove that a set $X$ is countable by finding a bijection $X \to \mathbb{N}$.
 
 \begin{exercise}
+\plan{7.1}{Aanbevolen}
 Prove that the function $p : \mathbb{N} \times \mathbb{N} \to \mathbb{N}$ defined by $p(x,y) = 2^x(2y+1)-1$ is a bijection. Deduce that $\mathbb{N} \times \mathbb{N}$ is countable.
 \hintlabel{exNCrossNIsCountable}{%
 The fundamental theorem of arithmetic (\Cref{thmFTA}) implies that, for all $n \in \mathbb{N}$, we can express $n+1$ uniquely as a power of $2$ multiplied by an odd number. 
@@ -86,6 +89,7 @@ Conversely, suppose $Y$ is countably infinite. Then there is a bijection $h : \m
 \end{cproof}
 
 \begin{exercise}
+\plan{7.1}{Essentieel}
 Prove if $X$ and $Y$ are countably infinite sets, then $X \times Y$ is countably infinite.
 \hintlabel{exProductOfTwoCountableSetsIsCountable}{%
 Use \Cref{exCartesianProductOfBijections}, together with the definition of countably infinite sets, to construct a bijection $\mathbb{N} \times \mathbb{N} \to X \times Y$. Then apply \Cref{exNCrossNIsCountable} and \Cref{propCountablyInfiniteFromBijection}.
@@ -167,6 +171,7 @@ So $f$ is a bijection, as required.
 \end{cproof}
 
 \begin{exercise}
+\plan{7.1}{Aanbevolen}
 Let $X$ be a countably infinite set. In the proof of $\text{(iii)} \Rightarrow \text{(i)}$ in \Cref{thmCountableFromInjSurj}, we gave an explicit construction of a bijection $f : \mathbb{N} \to X$ using a surjection $h : \mathbb{N} \to X$. Prove $\text{(ii)} \Rightarrow \text{(i)}$ the same way---that is, explain how to construct a bijection $f : \mathbb{N} \to X$ using an injection $g : X \to \mathbb{N}$.
 \hintlabel{exConstructBijectionFromInjection}{%
 Intuitively, we should be able to define $f$ by listing the values of $g$ in increasing order and, for all $n \in \mathbb{N}$, defining $f(n)$ to be the element $x \in X$ for which $g(x)$ is the $n^{\text{th}}$ (counting from $0$) value in the list. Your task is to make this precise. Be sure to note where in your proof you use injectivity of $g$.}
@@ -175,6 +180,7 @@ Intuitively, we should be able to define $f$ by listing the values of $g$ in inc
 \Cref{thmCountableFromInjSurj} allows us to deduce that sets are countable by finding injections with codomain $\mathbb{N}$ or surjections with domain $\mathbb{N}$, and without needing to find a bijection explicitly. It turns out we can do even better: we can replace $\mathbb{N}$ in \Cref{thmCountableFromInjSurj} with any set that is already known to be countable.
 
 \begin{exercise}
+\plan{7.1}{Essentieel}
 \label{exCountabilityFromInjectionsAndSurjections}
 Let $X$ be an non-empty set. The following are equivalent:
 \begin{enumerate}[(i)]
@@ -209,6 +215,7 @@ By \Cref{exCountableFromInjSurjC}, it follows that $\mathbb{Q}$ is countable.
 % To do: concept used before introduced - define (X choose k) in Section 6.1
 
 \begin{exercise} \label{exFiniteSubsetsCountableFixedSize}
+\plan{7.1}{Essentieel}
 Let $X$ be a countable set. Prove that $\binom{X}{k}$ is countable for each $k \in \mathbb{N}$.
 \begin{backhint}
 \hintref{exFiniteSubsetsCountableFixedSize}
@@ -320,6 +327,7 @@ Hence $f$ is not surjective, so that $\mathbb{R}$ is uncountable.
 \end{cproof}
 
 \begin{exercise}
+\plan{7.2}{Essentieel}
 Use Cantor's diagonal argument to prove that the set $\mathbb{N}^{\mathbb{N}}$ of all functions $\mathbb{N} \to \mathbb{N}$ is uncountable.
 \end{exercise}
 
@@ -359,10 +367,12 @@ by \Cref{thmCharacteristicFunctionsCharacteriseSubsets}. But then $F$ is injecti
 It so happens that the function $F$ defined in the proof of \Cref{propBinarySequencesAreUncountable} is \textit{bijective}, not just injective; however, we did not prove this, since it was not needed in our proof.
 
 \begin{exercise}
+\plan{7.2}{Essentieel}
 Prove that if a set $X$ has an uncountable subset, then $X$ is uncountable.
 \end{exercise}
 
 \begin{exercise}
+\plan{7.2}{Aanbevolen}
 \label{exPowerSetFiniteOrUncountable}
 Let $X$ be a set. Prove that $\mathcal{P}(X)$ is either finite or uncountable.
 \begin{backhint}

--- a/book/functions/functions.tex
+++ b/book/functions/functions.tex
@@ -158,6 +158,7 @@ can be represented by graph plot in \Cref{figGraphOfXOverTwo}.
 \end{example}
 
 \begin{exercise}
+\plan{3.1}{Aanbevolen}
 Find a function $f : \mathbb{Z} \to \mathbb{Z}$ whose graph is equal to the set
 \[ \{ \dots, ({-2}, {-5}), ({-1}, {-2}), (0, 1), (1, 4), (2, 7), (3, 10), \dots \} \]
 \end{exercise}
@@ -186,6 +187,7 @@ does not define the graph of a function $\{ 1, 2, 3 \} \to \{ \mathsf{red}, \mat
 \end{example}
 
 \begin{exercise}
+\plan{3.1}{Essentieel}
 For each of the following specifications of sets $X$, $Y$, $G$, determine whether or not $G$ is the graph of a function from $X$ to $Y$.
 \begin{enumerate}[(a)]
 \item $X = \mathbb{R}$, $Y = \mathbb{R}$, $G = \{ (a, a^2) \mid a \in \mathbb{R} \}$;
@@ -229,6 +231,7 @@ Notice that the function $r : (0, \infty) \to (0, \infty)$ from \Cref{exPositive
 \end{example}
 
 \begin{exercise}
+\plan{3.1}{Essentieel}
 Which of the following specifications of functions are well-defined?
 \begin{enumerate}[(a)]
 \item $g : \mathbb{Q} \to \mathbb{Q}$ defined by the equation $(x+1)g(x)=1$ for all $x \in \mathbb{Q}$;
@@ -239,6 +242,7 @@ Which of the following specifications of functions are well-defined?
 \end{exercise}
 
 \begin{exercise}
+\plan{3.1}{Aanbevolen}
 \label{exWellDefinednessOfFunctionOnUnion}
 Find a condition on sets $X$ and $Y$ such that the specification of a function $i : X \cup Y \to \{ 0, 1 \}$ given by
 \[ i(z) = \begin{cases} 0 & \text{if } z \in X \\ 1 & \text{if } z \in Y \end{cases} \]
@@ -286,6 +290,7 @@ where
 \end{example}
 
 \begin{exercise}
+\plan{3.1}{Aanbevolen}
 Let $f,g,h,k : \mathbb{Q} \to \mathbb{Q}$ be as in \Cref{exDecompositionOfFunctionQToQ}. Compute equations defining the following composites:
 \begin{enumerate}[(a)]
 \item $f \circ g$;
@@ -311,6 +316,7 @@ Equality of the three functions in question follows.
 \end{example}
 
 \begin{exercise}
+\plan{3.1}{Bonus}
 \label{exCompositionIsAssociative}
 Prove that composition of functions is \textit{associative}, that is, if $f : X \to Y$, $g : Y \to Z$ and $h : Z \to W$ are functions, then
 \[ h \circ (g \circ f) = (h \circ g) \circ f : X \to W \]
@@ -442,6 +448,7 @@ We have shown by double containment that $f[\mathbb{R}] = [0,\infty)$.
 \end{example}
 
 \begin{exercise}
+\plan{3.1}{Aanbevolen}
 For each of the following functions $f$ and subsets $U$ of their domain, describe the image $f[U]$.
 \begin{enumerate}[(a)]
 \item $f : \mathbb{Z} \to \mathbb{Z}$ defined by $f(n)=3n$, with $U = \mathbb{N}$;
@@ -460,6 +467,7 @@ Let $f : X \to Y$ be a function and let $U, V \subseteq X$. Then $f[U \cap V] \s
 \end{example}
 
 \begin{exercise}
+\plan{3.1}{Essentieel}
 Let $f : X \to Y$ be a function and let $U, V \subseteq X$. We saw in \Cref{exImageOfIntersectionSubsetIntersectionOfImage} that $f[U \cap V] \subseteq f[U] \cap f[V]$. Determine which of the following is true, and for each, provide a proof of its truth or falsity:
 \begin{enumerate}[(a)]
 \item $f[U] \cap f[V] \subseteq f[U \cap V]$;
@@ -495,6 +503,7 @@ Let $f : X \to Y$ be a function, let $U \subseteq X$ and let $V \subseteq Y$. Th
 The following exercise demonstrates that preimages interact very nicely with the basic set operations (intersection, union and relative complement):
 
 \begin{exercise}
+\plan{3.1}{Aanbevolen}
 Let $f : X \to Y$ be a function. Prove that $f^{-1}[\varnothing] = \varnothing$ and $f^{-1}[Y]=X$.
 \end{exercise}
 

--- a/book/functions/functions.tex
+++ b/book/functions/functions.tex
@@ -231,7 +231,7 @@ Notice that the function $r : (0, \infty) \to (0, \infty)$ from \Cref{exPositive
 \end{example}
 
 \begin{exercise}
-\plan{3.1}{Essentieel}
+\plan[abc]{3.1}{Essentieel}
 Which of the following specifications of functions are well-defined?
 \begin{enumerate}[(a)]
 \item $g : \mathbb{Q} \to \mathbb{Q}$ defined by the equation $(x+1)g(x)=1$ for all $x \in \mathbb{Q}$;

--- a/book/functions/injections-surjections.tex
+++ b/book/functions/injections-surjections.tex
@@ -83,10 +83,12 @@ So assume $(g \circ f)(a) = (g \circ f)(b)$. By definition of function compositi
 \end{cproof}
 
 \begin{exercise}
+\plan{3.2}{Essentieel}
 Let $f : X \to Y$ and $g : Y \to Z$ be functions. Prove that if $g \circ f$ is injective, then $f$ is injective.
 \end{exercise}
 
 \begin{exercise}
+\plan{3.2}{Aanbevolen}
 Write out what it means to say a function $f : X \to Y$ is \textit{not} injective, and say how you would prove that a given function is not injective. Give an example of a function which is not injective, and use your proof technique to write a proof that it is not injective.
 \end{exercise}
 
@@ -100,6 +102,7 @@ For each of the following functions, determine whether it is injective or not in
 \end{exercise}
 
 \begin{exercise}
+\plan{3.2}{Essentieel}
 \label{exLinearPolynomialIsInjective}
 Let $a,b \in \mathbb{R}$ with $b \ne 0$, and define $f : \mathbb{R} \to \mathbb{R}$ by $f(t) = a+bt$ for all $t \in \mathbb{R}$. Prove that $f$ is injective.
 \end{exercise}
@@ -148,6 +151,7 @@ Fix $n \in \mathbb{N}$ with $n > 0$, and define a function $r : \mathbb{Z} \to [
 \end{example}
 
 \begin{exercise}
+\plan{3.2}{Essentieel}
 For each of the following pairs of sets $(X,Y)$, determine whether the function $f : X \to Y$ defined by $f(x)=2x+1$ is surjective.
 \begin{enumerate}[(a)]
 \item $X = \mathbb{Z}$ and $Y = \{ x \in \mathbb{Z} \mid x \text{ is odd} \}$;
@@ -165,6 +169,7 @@ Recall \Cref{defImage}.
 \end{exercise}
 
 \begin{exercise}
+\plan{3.2}{Essentieel}
 Let $f : X \to Y$ be a function. Prove that $f$ is surjective if and only if $Y=f[X]$
 \end{exercise}
 
@@ -180,6 +185,7 @@ If $Z$ were a subset of $Y$, then we could easily define an injection $i : Z \to
 \end{exercise}
 
 \begin{exercise}
+\plan{3.2}{Aanbevolen}
 Let $f : X \to \mathcal{P}(X)$ be a function. By considering the set $B = \{ x \in X \mid x \not\in f(x) \}$, prove that $f$ is not surjective.
 \hintlabel{exRussellSubset}{%
 Note that $B \in \mathcal{P}(X)$. Prove that there does not exist $a \in X$ such that $B = f(a)$.
@@ -221,6 +227,7 @@ Since $f$ is both injective and surjective, it is bijective.
 \end{example}
 
 \begin{exercise}
+\plan{3.2}{Aanbevolen}
 
 Let $X$ be a set. Prove that the identity function $\mathrm{id}_X : X \to X$ is a bijection.
 \hintlabel{exIdentityBijection}{%
@@ -237,6 +244,7 @@ Since $\mathrm{id}_X$ is both injective and surjective, it is bijective. \qed
 \end{exercise}
 
 \begin{exercise}
+\plan{3.2}{Essentieel}
 \label{exCompositeOfBijectionsIsBijection}
 Let $f : X \to Y$ and $g : Y \to Z$ be bijections. Prove that $g \circ f$ is a bijection.
 \end{exercise}
@@ -283,6 +291,7 @@ and so $d$ is a left inverse for $e$.
 \end{example}
 
 \begin{exercise}
+\plan{3.2}{Aanbevolen}
 \label{exIfHasLeftInverseThenInjective}
 Let $f : X \to Y$ be a function. Prove that if $f$ has a left inverse, then $f$ is injective.
 \end{exercise}
@@ -447,6 +456,7 @@ Since $g$ is a left inverse for $f$ and a right inverse for $f$, it is a two-sid
 \end{example}
 
 \begin{exercise}
+\plan{3.2}{Aanbevolen}
 \label{exFindTwoSidedInverses}
 The following functions have two-sided inverses. For each, find its inverse and prove that it is indeed an inverse.
 \begin{enumerate}[(a)]
@@ -463,6 +473,7 @@ For part (c), don't try to write a formula for the inverse of $h$; instead, use 
 In light of the correspondences between injections and left inverses, and surjections and right inverses, it may be unsurprising that there is a correspondence between \textit{bijections} and \textit{two-sided inverses}.
 
 \begin{exercise}
+\plan{3.2}{Essentieel}
 \label{exBijectiveIffHasInverse}
 Let $f : X \to Y$ be a function. Then $f$ is bijective if and only if $f$ has an inverse.
 \end{exercise}
@@ -520,6 +531,7 @@ So indeed $g$ is a right inverse for $f$.
 \end{cproof}
 
 \begin{exercise}
+\plan{3.2}{Aanbevolen}
 \label{exInverseBijection}
 Let $f : X \to Y$ be a bijection. Prove that $f^{-1} : Y \to X$ is a bijection.
 \begin{backhint}
@@ -529,11 +541,13 @@ Use \Cref{exBijectiveIffHasInverse}.
 \end{exercise}
 
 \begin{exercise}
+\plan{3.2}{Aanbevolen}
 \label{exCompositeBijection}
 Let $f : X \to Y$ and $g : Y \to Z$ be bijections. Prove that $g \circ f : X \to Z$ is a bijection, and write an expression for its inverse in terms of $f^{-1}$ and $g^{-1}$.
 \end{exercise}
 
 \begin{exercise}
+\plan{3.2}{Essentieel}
 Let $f : X \to A$ and $g : Y \to B$ be bijections. Prove that there is a bijection $X \times Y \to A \times B$, and describe its inverse.
 \hintlabel{exCartesianProductOfBijections}{%
 Define $h : X \times Y \to A \times B$ by $h(x,y) = (f(x), g(y))$ for all $x \in X$ and all $y \in Y$; find an inverse for $h$ in terms of the inverses of $f$ and $g$.

--- a/book/functions/injections-surjections.tex
+++ b/book/functions/injections-surjections.tex
@@ -456,7 +456,7 @@ Since $g$ is a left inverse for $f$ and a right inverse for $f$, it is a two-sid
 \end{example}
 
 \begin{exercise}
-\plan{3.2}{Aanbevolen}
+\plan[ab]{3.2}{Aanbevolen}
 \label{exFindTwoSidedInverses}
 The following functions have two-sided inverses. For each, find its inverse and prove that it is indeed an inverse.
 \begin{enumerate}[(a)]

--- a/book/functions/q.tex
+++ b/book/functions/q.tex
@@ -191,7 +191,7 @@ Avoid the temptation to prove either part of this question by contradiction. For
 
 \begin{chapex}
 \chplan{3.2}{Essentieel}
-\chplan{7.2}{Aanbevolen}
+\chplan[e]{7.2}{Aanbevolen}
 \label{cqInjectionSurjectionBijection}
 For each of the following pairs $(U,V)$ of subsets of $\mathbb{R}$, determine whether the specification `$f(x) = x^2-4x+7$ for all $x \in U$' defines a function $f : U \to V$ and, if it does, determine whether $f$ is injective and whether $f$ is surjective.
 \begin{multicols}{2}
@@ -207,8 +207,8 @@ For each of the following pairs $(U,V)$ of subsets of $\mathbb{R}$, determine wh
 \end{chapex}
 
 \begin{chapex}
-\chplan{7.2}{Aanbevolen}
-\chplan{7.2}{Bonus}
+\chplan[b]{7.2}{Aanbevolen}
+\chplan[cd]{7.2}{Bonus}
 For each of the following pairs of sets $X$ and $Y$, find (with proof) a bijection $f : X \to Y$.
 \begin{enumerate}[(a)]
 \item $X = \mathbb{Z}$ and $Y = \mathbb{N}$;

--- a/book/functions/q.tex
+++ b/book/functions/q.tex
@@ -14,6 +14,7 @@ For each of the following equations, determine whether there exists a function $
 \end{chapex}
 
 \begin{chapex}
+\chplan{3.1}{Aanbevolen}
 Let $X$ be a set. Prove that
 \[ \forall a \in X,\, \exists ! U \in \mathcal{P}(X), (a \in U \wedge \exists ! x \in X,\, x \in U) \]
 Give an explicit description of the function $X \to \mathcal{P}(X)$ that is suggested by this logical formula.
@@ -90,6 +91,7 @@ $f : \mathbb{R} \to \mathbb{R}$; $f(x) = \sqrt{1+x^2}$ for all $x \in \mathbb{R}
 \end{chapex}
 
 \begin{chapex}
+\chplan{3.1}{Essentieel}
 $f : \mathbb{Z} \times \mathbb{Z} \to \mathbb{Z}$; $f(a,b) = a+2b$ for all $(a,b) \in \mathbb{Z} \times \mathbb{Z}$; $U = \{ 1 \} \times \mathbb{Z}$.
 \end{chapex}
 
@@ -112,6 +114,7 @@ $f : \mathbb{R} \to \mathbb{R}$; $f(x) = \sqrt{1+x^2}$ for all $x \in \mathbb{R}
 \end{chapex}
 
 \begin{chapex}
+\chplan{3.1}{Essentieel}
 $f : \mathbb{Z} \times \mathbb{Z} \to \mathbb{Z}$; $f(a,b) = a+2b$ for all $(a,b) \in \mathbb{Z} \times \mathbb{Z}$; $V = \{ n \in \mathbb{Z} \mid n \text{ is odd} \}$.
 \end{chapex}
 
@@ -121,6 +124,7 @@ $f : \mathcal{P}(\mathbb{N}) \times \mathcal{P}(\mathbb{N}) \to \mathcal{P}(\mat
 \end{chapex}
 
 \begin{chapex}
+\chplan{3.1}{Essentieel}
 Let $f : X \to Y$ be a function. For each of the following statements, either prove it is true or find a counterexample.
 \begin{multicols}{2}
 \begin{enumerate}[(a)]
@@ -175,6 +179,7 @@ Prove it by double containment, and carefully unpack the definitions of what it 
 \subsection*{Injections, surjections and bijections}
 
 \begin{chapex}
+\chplan{3.2}{Essentieel}
 \begin{enumerate}[(a)]
 \item Prove that, for all functions $f : X \to Y$ and $g : Y \to Z$, if $g \circ f$ is bijective, then $f$ is injective and $g$ is surjective.
 \item Find an example of a function $f : X \to Y$ and a function $g : Y \to Z$ such that $g \circ f$ is bijective, $f$ is not surjective and $g$ is not injective.
@@ -185,6 +190,8 @@ Avoid the temptation to prove either part of this question by contradiction. For
 \end{chapex}
 
 \begin{chapex}
+\chplan{3.2}{Essentieel}
+\chplan{7.2}{Aanbevolen}
 \label{cqInjectionSurjectionBijection}
 For each of the following pairs $(U,V)$ of subsets of $\mathbb{R}$, determine whether the specification `$f(x) = x^2-4x+7$ for all $x \in U$' defines a function $f : U \to V$ and, if it does, determine whether $f$ is injective and whether $f$ is surjective.
 \begin{multicols}{2}
@@ -200,6 +207,8 @@ For each of the following pairs $(U,V)$ of subsets of $\mathbb{R}$, determine wh
 \end{chapex}
 
 \begin{chapex}
+\chplan{7.2}{Aanbevolen}
+\chplan{7.2}{Bonus}
 For each of the following pairs of sets $X$ and $Y$, find (with proof) a bijection $f : X \to Y$.
 \begin{enumerate}[(a)]
 \item $X = \mathbb{Z}$ and $Y = \mathbb{N}$;
@@ -249,10 +258,12 @@ The image of a function is a subset of its domain.
 \end{chapex}
 
 \begin{chapex} % True
+\chplan{3.1}{Essentieel}
 Given a function $f : X \to Y$, the assignment $V \mapsto f^{-1}[V]$ defines a function $\mathcal{P}(Y) \to \mathcal{P}(X)$.
 \end{chapex}
 
 \begin{chapex} % True
+\chplan{3.2}{Aanbevolen}
 Let $f$, $g$ and $h$ be composable functions. If $h \circ g \circ f$ is injective, then $g$ is injective.
 \end{chapex}
 
@@ -266,11 +277,13 @@ Every left inverse is surjective and every right inverse is injective.
 \asnquestiontext{cqFunctionsASNBegin}{cqFunctionsASNEnd}
 
 \begin{chapex} % Always
+\chplan{3.1}{Aanbevolen}
 \label{cqFunctionsASNBegin}
 Let $f : X \to Y$ be a function and let $U \subseteq X$. Then there is a function $g : U \to Y$ defined by $g(x) = f(x)$ for all $x \in U$.
 \end{chapex}
 
 \begin{chapex} % Sometimes
+\chplan{3.1}{Aanbevolen}
 Let $f : X \to Y$ be a function and let $V \subseteq Y$. Then there is a function $g : X \to V$ defined by $g(x) = f(x)$ for all $x \in X$.
 \end{chapex}
 
@@ -283,6 +296,7 @@ Let $X$ be a set. Then there is a unique function $X \to \varnothing$.
 \end{chapex}
 
 \begin{chapex} % Sometimes
+\chplan{3.1}{Essentieel}
 Let $X$ and $Y$ be sets and let $G \subseteq X \times Y$. Then $G$ is the graph of a function $f : X \to Y$.
 \end{chapex}
 
@@ -307,6 +321,7 @@ Let $f : \{ 1, 2 \} \to \{ 1, 2, 3 \}$ be a function. Then $f$ is surjective.
 \end{chapex}
 
 \begin{chapex} % Always
+\chplan{3.2}{Aanbevolen}
 Let $a,b,c,d \in \mathbb{R}$ and define $f : \mathbb{R}^2 \to \mathbb{R}^2$ by $f(x,y) = (ax+by,cx+dy)$ for all $(x,y) \in \mathbb{R}^2$. Then $f$ is injective if and only if $f$ is surjective.
 \hintlabel{cqLinearMapInjectiveIffSurjective}{%
 First prove that $f$ is bijective if and only if $ad \ne bc$.
@@ -314,6 +329,7 @@ First prove that $f$ is bijective if and only if $ad \ne bc$.
 \end{chapex}
 
 \begin{chapex} % Sometimes
+\chplan{3.2}{Essentieel}
 \label{cqFunctionsASNEnd}
 Let $U, V \subseteq \mathbb{R}$ and suppose that $x^2 \in V$ for all $x \in U$. The function $f : U \to V$ defined by $f(x) = x^2$ is injective.
 \end{chapex}

--- a/book/getting-started/getting-started.tex
+++ b/book/getting-started/getting-started.tex
@@ -23,8 +23,8 @@ A \textbf{proposition} is a statement to which it makes sense to assign a \textb
 Thus the statements given at the beginning of this section are not propositions because there is no possible way of assigning them a truth value. Note that, in \Cref{defProposition}, all that matters is that it \textit{makes sense} to say that it is true or false, regardless of whether it actually \textit{is} true or false---the truth value of many propositions is unknown, even very simple ones.
 
 \begin{exercise}
+\plan{1.1}{Essentieel}
 \label{exExamplesOfPropositions}
-\plan{1.1}{Aanb}
 Think of an example of (a) a true proposition; (b) a false proposition; and (c) a proposition whose truth value you don't know.
 \solution{exExamplesOfPropositions}{%
 \fixlistskip
@@ -233,6 +233,7 @@ Set $n = \floor{x}$. Then $n \le x < n+1$ by definition of floor. Since $x$ is n
 \end{exercise}
 
 \begin{exercise}
+\plan{1.1}{Aanbevolen}
 Suppose that $x$ is a real number. Prove that $\floor{-x} = -\ceil{x}$ and $\ceil{-x} = -\floor{x}$.
 \hintlabel{exFloorCeilingOfNegative}{%
 Set $n = \floor{-x}$ and show that $-n$ satisfies the definition of being the ceiling of $x$; use a similar argument for the other part of the exercise.
@@ -363,6 +364,7 @@ By \Cref{defSetsPreliminary} and \Cref{defNumberSets}, the expression $x \in \In
 \end{example}
 
 \begin{exercise}
+\plan{1.1}{Essentieel}
 \label{exElementsOfNumberSets}
 Determine the truth values of the following propositions.
 \begin{multicols}{3}
@@ -462,6 +464,7 @@ is meaningless, since we have not defined a notion of `evenness' for rational nu
 
 
 \begin{exercise}
+\plan{1.1}{Essentieel}
 \label{exDyadicRatioal}
 \index{rational number!dyadic}
 A \textbf{dyadic rational} is a rational number that can be expressed as an integer divided by a power of $2$. Express the set of all dyadic rationals using set-builder notation in at least two different ways.
@@ -606,6 +609,7 @@ The fact that there are ten digits, and that the numeral system is based on powe
 It is therefore worthwhile to have some understanding of positional numeral systems based on numbers other than ten. The mathematical abstraction we make leads to the definition of \textit{base-$b$ expansion}.
 
 \begin{definition}
+\plan{1.1}{Aanbevolen}
 \label{defBaseBExpansionPreliminary}
 \index{base-$b$ expansion}
 \index{number base}
@@ -683,6 +687,7 @@ A consequence of \Cref{exOneDividesEveryIntegerDividesZero} is that $0$ is divis
 Using \Cref{defDivisionPreliminary}, we can prove some general basic facts about divisibility.
 
 \begin{proposition}
+\plan{1.1}{Aanbevolen}
 \label{propDivisibilityIsTransitive}
 Let $a,b,c \in \Int$. If $c$ divides $b$ and $b$ divides $a$, then $c$ divides $a$.
 \end{proposition}
@@ -705,6 +710,7 @@ Let $a,b,d \in \Int$. Suppose that $d$ divides $a$ and $d$ divides $b$. Given in
 Some familiar concepts, such as evenness and oddness, can be characterised in terms of divisibility.
 
 \begin{definition}
+\plan{1.1}{Essentieel}
 \label{defEvenOdd}
 \index{even!integer}
 \index{odd!integer}
@@ -762,6 +768,7 @@ This suggests the following algorithm for computing the base-$b$ expansion of a 
 \end{itemize}
 
 \begin{example}
+\plan{1.1}{Aanbevolen}
 We compute the base-$17$ expansion of $15213$, using the letters $\mathrm{A}$--$\mathrm{G}$ to represent the numbers $10$ through $16$.
 \begin{itemize}
 \item $15213 = 894 \cdot 17 + 15$, so $d_0=15=\mathrm{F}$ and $n_0=894$.
@@ -1046,5 +1053,6 @@ and here is an illustration of the fact that $(-5) \cdot 4 = -20$:
 \end{itemize}
 
 \begin{exercise}
+\plan{1.1}{Aanbevolen}
 Interpret the operations of subtraction and division as geometric transformations of the real number line.
 \end{exercise}

--- a/book/getting-started/getting-started.tex
+++ b/book/getting-started/getting-started.tex
@@ -544,6 +544,7 @@ The hollow circles $\circ$ indicate that the endpoints are not included in the i
 Be warned that the use of the symbol $\infty$ is misleading, since it suggests that the symbol $\infty$ on its own has a specific meaning (or, worse, that it refers to a real number). It doesn't---it is just a symbol that suggests unboundedness of the interval in question. A less misleading way of writing $[a, \infty)$, for instance, might be $[a, {\to})$ or $\Real^{\ge a}$; however, $[a,\infty)$ is standard, so it is what we will write.
 
 \begin{exercise}
+\plan{1.1}{Aanbevolen}
 For each of the following illustrations, find the interval that it depicts. A filled circle $\bullet$ indicates that an end-point is included in the interval, whereas a hollow circle $\circ$ indicates that an end-point is not included in the interval.
 
 \begin{enumerate}[(a)]
@@ -609,7 +610,6 @@ The fact that there are ten digits, and that the numeral system is based on powe
 It is therefore worthwhile to have some understanding of positional numeral systems based on numbers other than ten. The mathematical abstraction we make leads to the definition of \textit{base-$b$ expansion}.
 
 \begin{definition}
-\plan{1.1}{Aanbevolen}
 \label{defBaseBExpansionPreliminary}
 \index{base-$b$ expansion}
 \index{number base}
@@ -678,6 +678,7 @@ It is also divisible by the negatives of all of those numbers; for example, $12$
 \end{example}
 
 \begin{exercise}
+\plan{1.1}{Aanbevolen}
 \label{exOneDividesEveryIntegerDividesZero}
 Prove that $1$ divides every integer, and that every integer divides $0$.
 \end{exercise}
@@ -687,7 +688,6 @@ A consequence of \Cref{exOneDividesEveryIntegerDividesZero} is that $0$ is divis
 Using \Cref{defDivisionPreliminary}, we can prove some general basic facts about divisibility.
 
 \begin{proposition}
-\plan{1.1}{Aanbevolen}
 \label{propDivisibilityIsTransitive}
 Let $a,b,c \in \Int$. If $c$ divides $b$ and $b$ divides $a$, then $c$ divides $a$.
 \end{proposition}
@@ -703,6 +703,7 @@ But $r(qc) = (rq)c$, and $rq$ is an integer, so it follows from \Cref{defDivisio
 % To do: draw attention to the wording of the proof, and the 'unpack definition - do something - apply definition' style of the proof.
 
 \begin{exercise}
+\plan{1.1}{Essentieel}
 \label{exDivisibilityIsLinear}
 Let $a,b,d \in \Int$. Suppose that $d$ divides $a$ and $d$ divides $b$. Given integers $u$ and $v$, prove that $d$ divides $au+bv$.
 \end{exercise}
@@ -710,7 +711,6 @@ Let $a,b,d \in \Int$. Suppose that $d$ divides $a$ and $d$ divides $b$. Given in
 Some familiar concepts, such as evenness and oddness, can be characterised in terms of divisibility.
 
 \begin{definition}
-\plan{1.1}{Essentieel}
 \label{defEvenOdd}
 \index{even!integer}
 \index{odd!integer}
@@ -748,6 +748,7 @@ Since $0<r<b$, we have $0<b-r<b$. Hence $-(q+1)$ is the quotient of $-a$ when di
 \end{cproof}
 
 \begin{exercise}
+\plan{1.1}{Aanbevolen}
 Prove that if an integer $a$ leaves a remainder of $r$ when divided by an integer $b$, then $a$ leaves a remainder of $r$ when divided by $-b$.
 \end{exercise}
 
@@ -768,7 +769,6 @@ This suggests the following algorithm for computing the base-$b$ expansion of a 
 \end{itemize}
 
 \begin{example}
-\plan{1.1}{Aanbevolen}
 We compute the base-$17$ expansion of $15213$, using the letters $\mathrm{A}$--$\mathrm{G}$ to represent the numbers $10$ through $16$.
 \begin{itemize}
 \item $15213 = 894 \cdot 17 + 15$, so $d_0=15=\mathrm{F}$ and $n_0=894$.
@@ -820,6 +820,7 @@ Let $a=b=\sqrt{2}$. Then $a$ and $b$ are irrational, and $ab=2=\frac{2}{1}$, whi
 \end{cproof}
 
 \begin{exercise}
+\plan{1.1}{Aanbevolen}
 Let $r$ be a rational number and let $a$ be an irrational number. Prove that it is possible that $ra$ be rational, and it is possible that $ra$ be irrational.
 \end{exercise}
 
@@ -1053,6 +1054,5 @@ and here is an illustration of the fact that $(-5) \cdot 4 = -20$:
 \end{itemize}
 
 \begin{exercise}
-\plan{1.1}{Aanbevolen}
 Interpret the operations of subtraction and division as geometric transformations of the real number line.
 \end{exercise}

--- a/book/getting-started/q.tex
+++ b/book/getting-started/q.tex
@@ -10,10 +10,12 @@ Let $a, b, c, d \in \mathbb{Z}$. Under what conditions is $(a+b\sqrt{2})(c+d\sqr
 \end{chapex}
 
 \begin{chapex}
+\chplan{1.1}{Essentieel}
 Suppose an integer $m$ leaves a remainder of $i$ when divided by $3$, and an integer $n$ leaves a remainder of $j$ when divided by $3$, where $0 \le i,j < 3$. Prove that $m+n$ and $i+j$ leave the same remainder when divided by $3$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{1.1}{Essentieel}
 What are the possible remainders of $n^2$ when divided by $3$, where $n \in \mathbb{Z}$?
 \end{chapex}
 
@@ -81,11 +83,13 @@ Prove that $x+yi$ is an algebraic number, where $x$ and $y$ are any two rational
 \tfquestiontext{cqGettingStartedTFBegin}{cqGettingStartedTFEnd}
 
 \begin{chapex} % False
+\chplan{1.1}{Aanbevolen}
 \label{cqGettingStartedTFBegin}
 Every integer is a natural number.
 \end{chapex}
 
 \begin{chapex} % True
+\chplan{1.1}{Aanbevolen}
 Every integer is a rational number.
 \end{chapex}
 
@@ -102,6 +106,7 @@ The square of every rational number is a rational number.
 \end{chapex}
 
 \begin{chapex} % False
+\chplan{1.1}{Essentieel}
 The square root of every positive rational number is a rational number.
 \end{chapex}
 
@@ -128,22 +133,27 @@ Let $n,b_1,b_2 \in \mathbb{N}$ with $1 < b_1 < b_2 < n$. Then the base-$b_1$ exp
 \end{chapex}
 
 \begin{chapex} % Sometimes
+\chplan{1.1}{Essentieel}
 Let $a,b,c \in \mathbb{Z}$ and suppose that $a$ divides $c$ and $b$ divides $c$. Then $ab$ divides $c$.
 \end{chapex}
 
 \begin{chapex} % Always
+\chplan{1.1}{Essentieel}
 Let $a,b,c \in \mathbb{Z}$ and suppose that $a$ divides $c$ and $b$ divides $c$. Then $ab$ divides $c^2$.
 \end{chapex}
 
 \begin{chapex} % Always
+\chplan{1.1}{Aanbevolen}
 Let $x,y \in \mathbb{Q}$ and let $a,b,c,d \in \mathbb{Z}$ with $cy+d \ne 0$. Then $\dfrac{ax+b}{cy+d} \in \mathbb{Q}$.
 \end{chapex}
 
 \begin{chapex} % Sometimes
+\chplan{1.1}{Aanbevolen}
 Let $\dfrac{a}{b}$ be a rational number. Then $a \in \mathbb{Z}$ and $b \in \mathbb{Z}$.
 \end{chapex}
 
 \begin{chapex} % Sometimes
+\chplan{1.1}{Aanbevolen}
 Let $x \in \mathbb{R}$ and assume that $x^2 \in \mathbb{Q}$. Then $x \in \mathbb{Q}$.
 \end{chapex}
 

--- a/book/includes/planning.tex
+++ b/book/includes/planning.tex
@@ -7,20 +7,20 @@
 }
 
 
-\newcommand{\plan}[2]{
+\newcommand{\plan}[3][]{
     \immediate\write\exerciseplanning{%
-        #1;%
         #2;%
+        #3;%
         exercise;%
-        \theexercise
+        \theexercise#1
     }
 }
-\newcommand{\chplan}[2]{
+\newcommand{\chplan}[3][]{
     \immediate\write\exerciseplanning{%
-        #1;%
         #2;%
+        #3;%
         chapex;%
-        \thechapex
+        \thechapex#1
     }
 }
 

--- a/book/infinity/cardinality.tex
+++ b/book/infinity/cardinality.tex
@@ -62,6 +62,7 @@ The \textbf{cardinality of the continuum} is the cardinal number $\mathfrak{c}$ 
 \end{definition}
 
 \begin{exercise}
+\plan{7.2}{Essentieel}
 \label{exIntervalFromMinusOneToOneHasCardinalityOfContinuum}
 Consider the function $f : \mathbb{R} \to (-1,1)$ defined by
 \[ f(x) = \dfrac{x}{1+|x|} \]
@@ -108,6 +109,7 @@ $\aleph_0 \le \mathfrak{c}$. To see this, note that the function $i : \mathbb{N}
 \end{example}
 
 \begin{exercise}
+\plan{7.2}{Essentieel}
 Prove that $n < \aleph_0$ for all $n \in \mathbb{N}$.
 \end{exercise}
 

--- a/book/infinity/q.tex
+++ b/book/infinity/q.tex
@@ -32,6 +32,7 @@ The set of all functions $\mathbb{Z} \to [2]$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{7.2}{Aanbevolen}
 The set of all subsets $U \subseteq \mathbb{N}$ such that neither $U$ nor $\mathbb{N} \setminus U$ is finite.
 \end{chapex}
 
@@ -80,11 +81,13 @@ A subset $D \subseteq \mathbb{R}$ is \textit{dense} if $(a-\varepsilon, a+\varep
 In \Crefrange{cqFindCardinalityBegin}{cqFindCardinalityEnd}, determine whether the cardinality of the set is equal to $\aleph_0$, equal to $\mathfrak{c}$, or greater than $\mathfrak{c}$.
 
 \begin{chapex}
+\chplan{7.2}{Essentieel}
 \label{cqFindCardinalityBegin}
 $\mathcal{P}(\mathbb{R})$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{7.2}{Essentieel}
 The set of all finite subsets of $\mathbb{R}$.
 \end{chapex}
 
@@ -97,6 +100,7 @@ $\mathbb{R} \times \mathbb{R}$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{7.2}{Aanbevolen}
 The set of all functions $f : \mathbb{N} \to \mathbb{R}$ such that $f(n) = 0$ for all but finitely many $n \in \mathbb{N}$.
 \end{chapex}
 
@@ -110,6 +114,7 @@ The set of all functions $\mathbb{R} \to \mathbb{R}$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{7.2}{Aanbevolen}
 Prove that there is a set $\mathcal{C}$ of pairwise disjoint circles in $\mathbb{R}^2$ such that $|\mathcal{C}| = \mathfrak{c}$; formally, a circle is a subset $C \subseteq \mathbb{R}^2$ of the form
 \[ C = \{ (x,y) \mid (x-a)^2 + (y-b)^2 = r^2 \} \]
 for some $a,b \in \mathbb{R}$ and some $r > 0$.
@@ -204,6 +209,8 @@ Think combinatorially. You should not try to generalise the recursive definition
 \tfquestiontext{cqInfinityTFBegin}{cqInfinityTFEnd}
 
 \begin{chapex} % True
+\chplan{7.2}{Aanbevolen}
+\chplan{7.2}{Essentieel}
 \label{cqInfinityTFBegin}
 For any two countably infinite sets $X$ and $Y$, there exists a bijection $X \to Y$.
 \end{chapex}
@@ -225,6 +232,8 @@ There are countably many infinite subsets of $\mathbb{N}$.
 \end{chapex}
 
 \begin{chapex} % True
+\chplan{7.2}{Aanbevolen}
+\chplan{7.2}{Essentieel}
 The set $\mathbb{N} \times \mathbb{Z} \times \mathbb{Q}$ is countably infinite.
 \end{chapex}
 
@@ -241,6 +250,7 @@ There exist sets $X$ and $Y$ of different cardinalities that have the same numbe
 \end{chapex}
 
 \begin{chapex} % False
+\chplan{7.2}{Essentieel}
 For all sets $X$, if $U \subsetneqq X$, then $|U| < |X|$.
 \end{chapex}
 
@@ -259,6 +269,7 @@ Let $X$ be a set and suppose that there exists an injection $\mathbb{N} \to X$. 
 \end{chapex}
 
 \begin{chapex} % Never
+\chplan{7.2}{Essentieel}
 Let $X$ be a set. Then $\mathcal{P}(X)$ is countably infinite.
 \end{chapex}
 

--- a/book/logical-structure/logical-equivalence.tex
+++ b/book/logical-structure/logical-equivalence.tex
@@ -615,7 +615,7 @@ We see that $p \Rightarrow (q \Rightarrow p)$ is true regardless of the truth va
 \end{example}
 
 \begin{exercise}
-\plan{2.1}{Essentieel}
+\plan[ace]{2.1}{Essentieel}
 \label{exTautologies}
 Prove that each of the following is a tautology:
 \begin{enumerate}[(a)]

--- a/book/logical-structure/logical-equivalence.tex
+++ b/book/logical-structure/logical-equivalence.tex
@@ -86,6 +86,7 @@ We have derived $(\neg p) \vee q$ from $p \Rightarrow q$ and vice versa, and so 
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Essentieel}
 \label{exPAndQImpliesRIffPImpliesRAndQImpliesR}
 Let $p$, $q$ and $r$ be propositional variables. Prove that the propositional formula $(p \vee q) \Rightarrow r$ is logically equivalent to $(p \Rightarrow r) \wedge (q \Rightarrow r)$.
 \end{exercise}
@@ -242,11 +243,13 @@ $p$ & $q$ & $r$ & $q \vee r$ & $p \wedge (q \vee r)$ & $p \wedge q$  & $p \wedge
 In the following exercises, we use truth tables to repeat the proofs of logical equivalence from \Cref{exImplicationInTermsOfDisjunction} and \Cref{exPAndQImpliesRIffPImpliesRAndQImpliesR}.
 
 \begin{exercise}
+\plan{2.1}{Essentieel}
 \label{exImplicationInTermsOfDisjunctionWithTruthTables}
 Use a truth table to prove that $p \Rightarrow q \equiv (\neg p) \vee q$.
 \end{exercise}
 
 \begin{exercise}
+\plan{2.1}{Essentieel}
 \label{exPAndQImpliesRIffPImpliesRAndQImpliesRWithTruthTables}
 Let $p$, $q$ and $r$ be propositional variables. Use a truth table to prove that the propositional formula $(p \vee q) \Rightarrow r$ is logically equivalent to $(p \Rightarrow r) \wedge (q \Rightarrow r)$.
 \end{exercise}
@@ -346,6 +349,7 @@ So assume that neither $m>8$ nor $n>8$. Then $m \le 8$ and $n \le 8$, so that $m
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Essentieel}
 Use the law of contraposition to prove that $p \Leftrightarrow q \equiv (p \Rightarrow q) \wedge ((\neg p) \Rightarrow (\neg q))$, and use the proof technique that this equivalence suggests to prove that an integer is even if and only if its square is even.
 \hintlabel{exIntegerEvenIffSquareEven}{%
 Express this statement as $\forall n \in \mathbb{Z},\, (n \text{ is even}) \Leftrightarrow (n^2 \text{ is even})$, and note that the negation of `$x$ is even' is `$x$ is odd'.
@@ -407,6 +411,7 @@ while the second statement translates to
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Essentieel}
 \label{exNegationOfImplication}
 Prove that $\neg (p \Rightarrow q) \equiv p \wedge (\neg q)$ twice, once using a truth table, and once using \Cref{exImplicationInTermsOfDisjunctionWithTruthTables} together with de Morgan's laws and the law of double negation.
 \end{exercise}
@@ -462,6 +467,7 @@ We prove by counterexample that not every integer is divisible by a prime number
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Aanbevolen}
 Prove by counterexample that not every rational number can be expressed as $\dfrac{a}{b}$ where $a \in \mathbb{Z}$ is even and $b \in \mathbb{Z}$ is odd.
 \hintlabel{exNotEveryRationalIsEvenDividedByOdd}{%
 Find a rational number all of whose representations as a ratio of two integers have an even denominator.
@@ -488,6 +494,7 @@ Here the subformula $\neg \neg q$ contains a negation operator immediately befor
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Aanbevolen}
 Determine which of the following logical formulae are maximally negated.
 \begin{enumerate}[(a)]
 \item $\forall x \in X,\, (\neg p(x)) \Rightarrow \forall y \in X, \neg (r(x,y) \wedge s(x,y))$;
@@ -608,6 +615,7 @@ We see that $p \Rightarrow (q \Rightarrow p)$ is true regardless of the truth va
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Essentieel}
 \label{exTautologies}
 Prove that each of the following is a tautology:
 \begin{enumerate}[(a)]

--- a/book/logical-structure/propositional-logic.tex
+++ b/book/logical-structure/propositional-logic.tex
@@ -216,6 +216,7 @@ We can express the proposition `$7$ is a prime factor of $28$' in the form $p \w
 \end{example}
 
 \begin{exercise}
+\plan{1.1}{Aanbevolen}
 \label{exJohnMathematicianPittsburgh}
 Express the proposition `John is a mathematician who lives in Pittsburgh' in the form $p \wedge q$, for propositions $p$ and $q$.
 \end{exercise}
@@ -267,6 +268,7 @@ Suppose that, somewhere in the process of proving a proposition, we arrive at th
 \end{example}
 
 \begin{exercise}
+\plan{1.1}{Aanbevolen}
 Suppose we are given three propositions $p$, $q$ and $r$ and we are given that $(p \wedge q) \wedge r$ is true.
 Use \Cref{strAssumingConjunctionsDirect} to prove that $q$ is true. 
 \end{exercise}
@@ -352,6 +354,7 @@ In addition to its clean and compact nature, this way of writing rules of infere
 From this proof tree, we obtain a strategy for proving a proposition of the form $(p \wedge q) \wedge r$. Namely, first prove $p$ and prove $q$, to conclude $p \wedge q$; and then prove $r$, to conclude $(p \wedge q) \wedge r$. This illustrates that the logical structure of a proposition informs how we may structure a proof of the proposition.
 
 \begin{exercise}
+\plan{1.1}{Aanbevolen}
 Write a proof tree whose conclusion is the propositional formula $(p \wedge q) \wedge (r \wedge s)$, where $p,q,r,s$ are propositional variables. Express `$2$ is an even prime number and $3$ is an odd prime number' in the form $(p \wedge q) \wedge (r \wedge s)$, for appropriate propositions $p$, $q$, $r$ and $s$, and describe how your proof tree suggests what a proof might look like.
 \end{exercise}
 
@@ -527,6 +530,7 @@ In both cases, $p \vee (q \wedge r)$ is true.
 \end{example}
 
 \begin{exercise}
+\plan{1.1}{Essentieel}
 Let $p$, $q$, and $r$ be propositions, and suppose $q \vee r$ is true. Prove that $(p \vee q) \vee (p \vee r)$ is true, using \Cref{strAssumingDisjunctionsDirect} and \Cref{strProvingDisjunctionsDirect}.
 \end{exercise}
 
@@ -554,6 +558,7 @@ Notice that in both Case 1 and Case 2, we did not explicitly mention that we had
 \end{example}
 
 \begin{exercise}
+\plan{1.1}{Aanbevolen}
   Let $n$ be either the number 8 or 9. Prove that $n$ is even or a perfect square.
 \end{exercise}
 
@@ -594,6 +599,7 @@ Note that in the proof of \Cref{propRemainderOfSquaresModulo3}, unlike in \Cref{
 When completing the following exercises, try to keep track of exactly where you use the introduction and elimination rules that we have seen so far.
 
 \begin{exercise}
+\plan{1.1}{Essentieel}
 Let $n$ be an integer. Prove that $n^2$ leaves a remainder of $0$, $1$ or $4$ when divided by $5$.
 \hintlabel{exSquareRemainderModuloFive}{
 Mimic the proof of \Cref{propRemainderOfSquaresModulo3}.
@@ -684,10 +690,12 @@ Let $p(x)$ be a polynomial over $\mathbb{C}$. Prove that if $\alpha$ is a root o
 The elimination rule for implication \elimrule{\Rightarrow} is more commonly known by the Latin name \textit{modus ponens}.
 
 \begin{exercise}
+\plan{1.2}{Essentieel}
 Let $r$ and $s$ be propositions. Prove that $r \Rightarrow (s \Rightarrow s)$ is true. Write your proof using the strategies discussed for implications.
 \end{exercise}
 
 \begin{exercise}
+\plan{1.2}{Essentieel}
 Let $a$, $b$, and $c$ be propositions. Prove that $(a \vee b) \Rightarrow (c \Rightarrow ((c \wedge a) \vee b))$ is true. Structure your proof by using the appropriate strategies you have learned so far.
 \end{exercise}
 
@@ -716,6 +724,7 @@ Given the polynomial $f(x) = x^2-68x+1156$, it would be a pain to go through the
 \end{example}
 
 \begin{exercise}
+\plan{1.2}{Aanbevolen}
 Let $p$, $q$, and $r$ be propositions. Prove that $(p \Rightarrow q \Rightarrow r) \Rightarrow (q \Rightarrow (p \Rightarrow r))$ is true.
 \hintlabel{exStrategy1_1_25_easy}{
 First use $p$ and $q$ as assumptions, then apply the implication.
@@ -723,6 +732,7 @@ First use $p$ and $q$ as assumptions, then apply the implication.
 \end{exercise}
 
 \begin{exercise}
+\plan{1.2}{Essentieel}
 Let $p$, $q$, and $r$ be propositions. Prove that $(p \Rightarrow p \wedge q) \Rightarrow ((p \vee q) \Rightarrow q)$ is true.
 \hintlabel{exStrategy1_1_25_mixed}{
 Consider cases for $p \vee q$ and use the implication appropriately.
@@ -778,6 +788,7 @@ Therefore, $p \Leftrightarrow q$ is true.
 \end{example}
 
 \begin{exercise}
+\plan{1.2}{Aanbevolen}
 Let $p$ and $q$ be propositions. We prove that $(p \Leftrightarrow q) \Leftrightarrow (q \Leftrightarrow p)$ is true.
 
 \end{exercise}
@@ -923,6 +934,7 @@ so indeed $8$ divides $n$, as required.
 \end{example}
 
 \begin{exercise}
+\plan{1.2}{Essentieel}
 Prove that a natural number $n$ is divisible by $3$ if and only if the sum of its base-$10$ digits is divisible by $3$.
 \hintlabel{exSumOfDigitsDivisibleByThree}{%
 Suppose $n = d_r \cdot 10^r + \cdots + d_1 \cdot 10 + d_0$ and let $s = d_r + \cdots + d_1 + d_0$. Start by proving that $3 \mid n-s$.
@@ -1021,21 +1033,25 @@ This contradicts the assumption that $a$ is irrational. It follows that $r+a$ is
 Now you can try proving some elementary facts by contradiction.
 
 \begin{exercise}
+\plan{1.2}{Aanbevolen}
 Let $p$ and $q$ be propositions. Prove that $(p \Rightarrow \neg q) \Rightarrow (q \Rightarrow \neg p)$ is true.
 
 \end{exercise}
 
 \begin{exercise}
+\plan{1.2}{Aanbevolen}
 Let $p$ and $q$ be propositions. Prove that $\neg p \Rightarrow (\neg q \Rightarrow \neg(p \vee q))$ is true.
 
 \end{exercise}
 
 \begin{exercise}
+\plan{1.2}{Essentieel}
 \label{exNegationAndReciprocalOfIrrationalNumbers}
 Let $x \in \mathbb{R}$. Prove by contradiction that if $x$ is irrational then $-x$ and $\frac{1}{x}$ are irrational.
 \end{exercise}
 
 \begin{exercise}
+\plan{1.2}{Essentieel}
 \label{exNoLeastPositiveReal}
 Prove by contradiction that there is no least positive real number. That is, prove that there is not a positive real number $a$ such that $a \le b$ for all positive real numbers $b$.
 \end{exercise}
@@ -1134,10 +1150,12 @@ Reflect on the proof of \Cref{propIfProductEvenThenSomeFactorEven}. Where in the
 \end{exercise}
 
 \begin{exercise}
+\plan{1.2}{Aanbevolen}
 Let $p$ and $q$ be propositions. Prove that $(\neg q \Rightarrow \neg p) \Rightarrow (p \Rightarrow q)$ is true.
 \end{exercise}
 
 \begin{exercise}
+\plan{1.2}{Aanbevolen}
 Let $a$ and $b$ be irrational numbers. By considering the number $\sqrt{2}^{\sqrt{2}}$, prove that it is possible that $a^b$ be rational.
 \hintlabel{exIrrationalExpIrrationalCanBeRational}{%
 Use the law of excluded middle according to whether the proposition `$\sqrt{2}^{\sqrt{2}}$ is rational' is true or false.}

--- a/book/logical-structure/q.tex
+++ b/book/logical-structure/q.tex
@@ -1,5 +1,6 @@
 % !TeX root = ../../infdesc.tex
 \begin{chapex}
+\chplan{1.2}{Essentieel}
 \label{cqTranslatePropositionalFormulaeToEnglish}
 For fixed $n \in \mathbb{N}$, let $p$ represent the proposition `$n$ is even', let $q$ represent the proposition `$n$ is prime' and let $r$ represent the proposition `$n = 2$'. For each of the following propositional formulae, translate it into plain English and determine whether it is true for all $n \in \mathbb{N}$, true for some values of $n$ and false for some values of $n$, or false for all $n \in \mathbb{N}$.
 
@@ -33,7 +34,6 @@ Let $p$ and $q$ be propositions, and assume that $p \Rightarrow (\neg q)$ is tru
 In \Crefrange{cqStructureProofBegin}{cqStructureProofEnd}, use the definitions of the logical operators in \Cref{secPropositionalLogic} to describe what steps should be followed in order to prove the propositional formula in the question; the letters $p$, $q$, $r$ and $s$ are propositional variables.
 
 \begin{chapex}
-\plan{week 1.2}{bonus}
 \label{cqStructureProofBegin}
 $(p \wedge q) \Rightarrow (\neg r)$
 \end{chapex}
@@ -54,6 +54,7 @@ $(p \wedge (\neg q)) \vee (q \wedge (\neg p))$
 % Variables and quantifiers %
 
 \begin{chapex}
+\chplan{1.2}{Aanbevolen}
 Find a statement in plain English, involving no variables at all, that is equivalent to the logical formula $\forall a \in \mathbb{Q},\, \forall b \in \mathbb{Q},\, (a < b \Rightarrow \exists c \in \mathbb{R},\, [a < c < b ~\wedge~ \neg (c \in \mathbb{Q})])$. Then prove this statement, using the structure of the logical formula as a guide.
 \end{chapex}
 
@@ -68,6 +69,7 @@ Let $X$ be a set and let $p(x)$ be a predicate. Find a logical formula represent
 % Logical equivalence %
 
 \begin{chapex}
+\chplan{2.1}{Aanbevolen}
 Prove that
 \[
 p \Leftrightarrow q \equiv (p \Rightarrow q) \wedge ((\neg p) \Rightarrow (\neg q))
@@ -148,6 +150,7 @@ This question explores this curious new logical operator.
 \end{chapex}
 
 \begin{chapex}
+\chplan{2.1}{Essentieel}
 Let $X$ be $\mathbb{Z}$ or $\mathbb{Q}$, and define a logical formula $p$ by:
 $$\forall x \in X,\, \exists y \in X,\, (x<y \wedge [\forall z \in X,\, \neg (x<z \wedge z<y)])$$
 Write out $\neg p$ as a maximally negated logical formula. Prove that $p$ is true when $X = \mathbb{Z}$, and $p$ is false when $X = \mathbb{Q}$.
@@ -195,14 +198,17 @@ The logical formulae $\neg \forall x \in X,\, \forall y \in Y,\, p(x,y)$ and $\e
 \end{chapex}
 
 \begin{chapex} % False
+\chplan{2.1}{Aanbevolen}
 $\neg \forall x \ge 0,\, \exists y \in \mathbb{R},\, y^2=x$ is logically equivalent to $\forall x < 0,\, \exists y \not\in \mathbb{R},\, y^2 \ne x$.
 \end{chapex}
 
 \begin{chapex} % True
+\chplan{2.1}{Aanbevolen}
 $\neg \forall x \ge 0,\, \exists y \in \mathbb{R},\, y^2=x$ is logically equivalent to $\exists x \ge 0,\, \forall y \in \mathbb{R},\, y^2 \ne x$.
 \end{chapex}
 
 \begin{chapex} % False
+\chplan{2.1}{Aanbevolen}
 \label{cqLogicTFEnd}
 $\neg \forall x \ge 0,\, \exists y \in \mathbb{R},\, y^2=x$ is logically equivalent to $\exists x < 0,\, \forall y \in \mathbb{R},\, y^2 = x$.
 \end{chapex}
@@ -212,11 +218,13 @@ $\neg \forall x \ge 0,\, \exists y \in \mathbb{R},\, y^2=x$ is logically equival
 \asnquestiontext{cqLogicASNBegin}{cqLogicASNEnd}
 
 \begin{chapex} % Sometimes
+\chplan{1.2}{Aanbevolen}
 \label{cqLogicASNBegin}
 Let $p$ and $q$ be propositions and assume that $p$ is true. Then $p \Rightarrow q$ is true.
 \end{chapex}
 
 \begin{chapex} % Always
+\chplan{1.2}{Aanbevolen}
 Let $p$ and $q$ be propositions and assume that $p$ is false. Then $p \Rightarrow q$ is true.
 \end{chapex}
 

--- a/book/logical-structure/variables-quantifiers.tex
+++ b/book/logical-structure/variables-quantifiers.tex
@@ -90,6 +90,7 @@ The (false) proposition `every integer is even' can then be written symbolically
 \end{example}
 
 \begin{exercise}
+\plan{1.2}{Essentieel}
 \label{exEnglishToLogicalFormulae}
 Find logical formulae that represent each of the following English statements.
 \begin{enumerate}[(a)]
@@ -238,10 +239,12 @@ In both cases, we have $x \le 0 \vee x \ge 0$, as required.
 \end{example}
 
 \begin{exercise}
+\plan{1.2}{Bonus}
 Prove that for every real number $x$, we have $x = x$.
 \end{exercise}
 
 \begin{exercise}
+\plan{1.2}{Essentieel}
   Prove that for every integer $n$, we have $n$ is even if and only if $n^2$ is even.
 \end{exercise}
 
@@ -256,6 +259,7 @@ Prove that every linear polynomial over $\mathbb{Q}$ has a rational root.
 
 
 \begin{exercise}
+\plan{1.2}{Essentieel}
 Prove that, for all real numbers $x$ and $y$, if $x$ is irrational, then $x+y$ and $x-y$ are not both rational.
 \hintlabel{exIrrationalPlusMinusRealNotBothRational}{%
 Consider the sum of $x+y$ and $x-y$.
@@ -294,10 +298,12 @@ Indeed, assume that $\forall x \in \mathbb{R}, P(x)$. Since $0 \in \mathbb{R}$, 
 \end{example}
 
 \begin{exercise}
+\plan{1.2}{Aanbevolen}
 Suppose that $P(x)$ is some predicate with free variable $x \in \mathbb{R}$, and we are given that $\forall x \in \mathbb{R}, P(x)$. Show that we can conclude $P(21)$.
 \end{exercise}
 
 \begin{exercise}
+\plan{1.2}{Aanbevolen}
 Let $P(x)$ and $Q(x)$ be predicates with free variable $x \in \mathbb{R}$. Prove that 
 \[(\forall x \in \mathbb{R}, P(x) \Rightarrow Q(x)) \Rightarrow (\forall x \in \mathbb{R}, P(x)) \Rightarrow (\forall x \in \mathbb{R}, Q(x))\]
 \end{exercise}
@@ -373,6 +379,7 @@ Prove that there is a real number which is irrational but whose square is ration
 \end{exercise}
 
 \begin{exercise}
+\plan{1.2}{Aanbevolen}
 Prove that there is an integer which is divisible by zero.
 \hintlabel{exZeroDividesSomeInteger}{%
 Look carefully at the definition of divisibility (\Cref{defDivisionPreliminary}).
@@ -456,6 +463,7 @@ so either $y-z=0$ or $y+z=0$. If $y+z=0$ then $z=-y$, and since $y>0$, this mean
 \end{example}
 
 \begin{exercise}
+\plan{1.2}{Aanbevolen}
 \label{exExamplesOfUniqueExistentialQuantifier}
 For each of the propositions, write it out as a logical formula involving the $\exists !$ quantifier and then prove it, using the structure of the logical formula as a guide.
 \begin{enumerate}[(a)]
@@ -509,6 +517,7 @@ This is a typical `real-world' example of what is known as \textit{quantifier al
 Here's another example with a more mathematical nature:
 
 \begin{exercise}
+\plan{1.2}{Essentieel}
 Let $p(x,y)$ be the statement `$x + y$ is even'.
 \begin{itemize}
 \item Prove that $\forall x \in \mathbb{Z},\, \exists y \in \mathbb{Z},\, p(x,y)$ is true.

--- a/book/logical-structure/variables-quantifiers.tex
+++ b/book/logical-structure/variables-quantifiers.tex
@@ -463,7 +463,7 @@ so either $y-z=0$ or $y+z=0$. If $y+z=0$ then $z=-y$, and since $y>0$, this mean
 \end{example}
 
 \begin{exercise}
-\plan{1.2}{Aanbevolen}
+\plan[ab]{1.2}{Aanbevolen}
 \label{exExamplesOfUniqueExistentialQuantifier}
 For each of the propositions, write it out as a logical formula involving the $\exists !$ quantifier and then prove it, using the structure of the logical formula as a guide.
 \begin{enumerate}[(a)]

--- a/book/mathematical-induction/q.tex
+++ b/book/mathematical-induction/q.tex
@@ -53,25 +53,30 @@ Let $N$ be a set, let $z \in N$ and let $s : N \to N$. Prove that $(N, z, s)$ is
 \subsection*{Proofs by induction}
 
 \begin{chapex}
+\chplan{4.1}{Essentieel}
 \label{cqNPowerFiveLessThanFivePowerN}
 Find all natural numbers $n$ such that $n^5 < 5^n$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{4.1}{Essentieel}
 Prove that $(1+x)^{123\;456\;789} \ge 1 + 123\;456\;789\;x$ for all real $x \ge -1$.
 \hintlabel{cqBernoullisInequality}{%
 Proving this by induction on $x$ only demonstrates that it is true for \textit{integers} $x \ge -1$, not \textit{real numbers} $x \ge -1$. Try proving a more general fact by induction on a different variable, and deducing this as a special case. (Do you \textit{really} think there is anything special about the natural number $123\;456\;789$?)}
 \end{chapex}
 
 \begin{chapex}
+\chplan{4.1}{Aanbevolen}
 Let $a \in \mathbb{N}$ and assume that the last digit in the decimal expansion of $a$ is $6$. Prove that the last digit in the decimal expansion of $a^n$ is $6$ for all $n \ge 1$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{4.2}{Essentieel}
 Let $a,b \in \mathbb{R}$, and let $a_0, a_1, a_2, \dots$ be a sequence such that $a_0 = a$, $a_1=b$ and $a_n = \dfrac{a_{n-1} + a_{n+1}}{2}$ for all $n \ge 1$. Prove that $a_n = a + (b-a) n$ for all $n \in \mathbb{N}$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{4.1}{Aanbevolen}
 Let $f : \mathbb{R} \to \mathbb{R}$ be a function such that $f(x+y) = f(x) + f(y)$ for all $x,y \in \mathbb{R}$.
 \begin{enumerate}[(a)]
 \item Prove by induction that there is a real number $a$ such that $f(n) = an$ for all $n \in \mathbb{N}$.
@@ -84,6 +89,7 @@ To find the value of $a$ in part (a), try substituting some small values of $x$ 
 \end{chapex}
 
 \begin{chapex}
+\chplan{4.1}{Aanbevolen}
 Let $f : \mathbb{R} \to \mathbb{R}$ be a function such that $f(0) > 0$ and $f(x+y)=f(x)f(y)$ for all $x,y \in \mathbb{R}$. Prove that there is some positive real number $a$ such that $f(x)=a^x$ for all \textit{rational} numbers $x$..
 \hintlabel{cqHomomorphismFromRPlusToRTimes}{%
 Like in \Cref{cqHomomorphismFromRPlusToRPlus}, prove this first for $x \in \mathbb{N}$ (by induction), then for $x \in \mathbb{Z}$, and finally for $x \in \mathbb{Q}$.
@@ -91,10 +97,12 @@ Like in \Cref{cqHomomorphismFromRPlusToRPlus}, prove this first for $x \in \math
 \end{chapex}
 
 \begin{chapex}
+\chplan{4.1}{Essentieel}
 Let $a,b \in \mathbb{Z}$. Prove that $b-a$ divides $b^n-a^n$ for all $n \in \mathbb{N}$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{4.1}{Essentieel}
 Prove by induction that $7^n - 2 \cdot 4^n + 1$ is divisible by $18$ for all $n \in \mathbb{N}$.
 \hintlabel{cqInductionEmbeddedInIductionStep}{%
 Observe that $7^{n+1} - 2 \cdot 4^{n+1} + 1 = 4(7^n - 2 \cdot 4^n + 1) + 3(7^n - 1)$ for all $n \in \mathbb{N}$. You may need to do a separate proof by induction in your induction step.
@@ -106,21 +114,25 @@ Observe that $7^{n+1} - 2 \cdot 4^{n+1} + 1 = 4(7^n - 2 \cdot 4^n + 1) + 3(7^n -
 \Crefrange{cqCalculusBegin}{cqCalculusEnd} assume familiarity with the basic techniques of differential and integral calculus.
 
 \begin{chapex}
+\chplan{4.1}{Essentieel}
 \label{cqCalculusBegin}
 Prove that $\dfrac{d^n}{dx^n}(xe^x) = (n+x)e^x$ for all $n \in \mathbb{N}$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{4.2}{Essentieel}
 Find and prove an expression for $\dfrac{d^n}{dx^n}(x^2e^x)$ for all $n \in \mathbb{N}$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{4.1}{Essentieel}
 Let $f$ and $g$ be differentiable functions. Prove that
 \[ \dfrac{d^n}{dx^n}(f(x)g(x)) = \sum_{k=0}^n \dbinom{n}{k} f^{(k)}(x) g^{(n-k)}(x) \]
 for all $n \in \mathbb{N}$, where the notation $h^{(r)}$ denotes the $r^{\text{th}}$ derivative of $h$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{4.1}{Aanbevolen}
 Find and prove an expression for the $n^{\text{th}}$ derivative of $\log(x)$ for all $n \in \mathbb{N}$.
 \end{chapex}
 
@@ -149,39 +161,48 @@ For (a) use integration by parts; you do not need induction. For parts (b) and (
 \tfquestiontext{cqInductionTFBegin}{cqInductionTFEnd}
 
 \begin{chapex} % True
+\chplan{4.1}{Aanbevolen}
 \label{cqInductionTFBegin}
 Every factorial is positive.
 \end{chapex}
 
 \begin{chapex} % False
+\chplan{4.1}{Essentieel}
 Every binomial coefficient is positive.
 \end{chapex}
 
 \begin{chapex} % False
+\chplan{4.2}{Essentieel}
 Every proof by strong induction can be turned into a proof by weak induction by changing only the induction hypothesis.
 \end{chapex}
 
 \begin{chapex} % True
+\chplan{4.2}{Essentieel}
 Every proof by weak induction can be turned into a proof by strong induction by changing only the induction hypothesis.
 \end{chapex}
 
 \begin{chapex} % True
+\chplan{4.2}{Aanbevolen}
 Given a set $X$, a surjection $f : \mathbb{N} \to X$ and a logical formula $p(x)$ with free variable $x \in X$, if $p(f(0))$ is true and $\forall n \in \mathbb{N},\, (p(f(n)) \Rightarrow p(f(n+1)))$ is true, then $\forall x \in X,\, p(x)$ is true.
 \end{chapex}
 
 \begin{chapex} % False
+\chplan{4.2}{Essentieel}
 Given some logical formula $p(x)$ with free variable $x \in \mathbb{N}$, if for all $x \in \mathbb{N}$ there exists some $y \le x$ such that $p(y)$ is false, then $p(x)$ is false for all $x \in \mathbb{N}$.
 \end{chapex}
 
 \begin{chapex} % False
+\chplan{4.2}{Essentieel}
 Every non-empty subset of the set $\mathbb{Q}^{\ge 0}$ of nonnegative rational numbers has a least element. 
 \end{chapex}
 
 \begin{chapex} % False
+\chplan{4.2}{Essentieel}
 Every non-empty subset of the set $\mathbb{Z}$ of integers has a least element.
 \end{chapex}
 
 \begin{chapex} % True
+\chplan{4.2}{Essentieel}
 \label{cqInductionTFEnd}
 Every non-empty subset of the set $\mathbb{Z}^{-}$ of negative integers has a greatest element.
 \end{chapex}
@@ -191,15 +212,18 @@ Every non-empty subset of the set $\mathbb{Z}^{-}$ of negative integers has a gr
 \asnquestiontext{cqInductionASNBegin}{cqInductionASNEnd}
 
 \begin{chapex} % Sometimes
+\chplan{4.1}{Aanbevolen}
 \label{cqInductionASNBegin}
 Let $n,k,\ell \in \mathbb{Z}$. Then $\dbinom{n}{k+\ell} = \dbinom{n}{k} + \dbinom{n}{\ell}$.
 \end{chapex}
 
 \begin{chapex} % Never
+\chplan{4.2}{Aanbevolen}
 Let $m,n \ge 2$. Then $(m+n)! = m!+n!$.
 \end{chapex}
 
 \begin{chapex} % Always
+\chplan{4.2}{Aanbevolen}
 \label{cqInductionASNEnd}
 Let $p(x)$ be a logical formula with free variable $x \in \mathbb{Z}$, and suppose that $p(0)$ is true and, for all $n \in \mathbb{Z}$, if $p(n)$ is true, then $p(n+1)$ and $p(n-2)$ are true. Then $\forall n \in \mathbb{Z},\, p(n)$ is true.
 \end{chapex}

--- a/book/mathematical-induction/strong-induction.tex
+++ b/book/mathematical-induction/strong-induction.tex
@@ -214,16 +214,19 @@ So the result follows by induction.
 The following exercises have proofs by strong induction with multiple base cases.
 
 \begin{exercise}
+\plan{4.2}{Essentieel}
 Define a sequence recursively by $a_0 = 4$, $a_1 = 9$ and $a_n = 5a_{n-1} - 6a_{n-2}$ for all $n \ge 2$. Prove that $a_n = 3 \cdot 2^n + 3^n$ for all $n \in \mathbb{N}$.
 \end{exercise}
 
 \begin{exercise}
+\plan{4.2}{Essentieel}
 The \textit{Tribonacci sequence} is the sequence $t_0, t_1, t_2, \dots$ defined by
 \[ t_0 = 0, \quad t_1 = 0, \quad t_2 = 1, \quad t_n = t_{n-1} + t_{n-2} + t_{n-3} \text{ for all } n \ge 3 \]
 Prove that $t_n \le 2^{n-3}$ for all $n \ge 3$.
 \end{exercise}
 
 \begin{exercise}
+\plan{4.2}{Aanbevolen}
 The \textit{Frobenius coin problem} asks when a given amount of money can be obtained from coins of given denominations. For example, a value of $7$ dubloons cannot be obtained using only $3$ dubloon and $5$ dubloon coins, but for all $n \ge 8$, a value of $n$ dubloons \textit{can} be obtained using only $3$ dubloon and $5$ dubloon coins. Prove this.
 \hintlabel{exFrobeniusCoinProblem}{%
 Observe that if $n$ dubloons can be obtained using only $3$ and $5$ dubloon coins, then so can $n+3$. See how you might use this fact to exploit strong induction with multiple base cases.
@@ -307,10 +310,12 @@ In the proof of \Cref{propSqrt2Irrational} we could have separately proved that 
 \end{writingtip}
 
 \begin{exercise}
+\plan{4.2}{Essentieel}
 What goes wrong in the proof of \Cref{propSqrt2Irrational} if we try instead to prove that $\sqrt{4}$ is irrational?
 \end{exercise}
 
 \begin{exercise}
+\plan{4.2}{Essentieel}
 \label{exSquareRootThreeIsIrrational}
 Prove that $\sqrt{3}$ is irrational.
 \begin{backhint}
@@ -335,6 +340,7 @@ There are many examples of subsets $X \subseteq \mathbb{R}$ with infinite descen
 \end{example}
 
 \begin{exercise}
+\plan{4.2}{Aanbevolen}
 Prove that the interval $(0,1)$ has infinite descent.
 \end{exercise}
 

--- a/book/mathematical-induction/weak-induction.tex
+++ b/book/mathematical-induction/weak-induction.tex
@@ -138,6 +138,7 @@ The result follows by induction.
 \end{cproof}
 
 \begin{exercise}
+\plan{4.1}{Essentieel}
 \label{exSumOfPowersOf2}
 Prove by induction that $\displaystyle \sum_{k=0}^n 2^k = 2^{n+1} - 1$ for all $n \in \mathbb{N}$.
 \end{exercise}
@@ -145,7 +146,6 @@ Prove by induction that $\displaystyle \sum_{k=0}^n 2^k = 2^{n+1} - 1$ for all $
 The following proposition has a proof by induction in which the base case is not zero.
 
 \begin{proposition}
-\plan{4.1}{Essentieel}
 \label{propWeakInductionNonzeroBaseCaseExample}
 For all $n \ge 4$, we have $3n < 2^n$.
 \end{proposition}
@@ -191,6 +191,7 @@ By induction, we're done.
 \end{example}
 
 \begin{exercise}
+\plan{4.1}{Aanbevolen}
 Write down the statement $p(n)$ that \Cref{exHorseInductionFail} attempted to prove for all $n \ge 1$. Convince yourself that the proof of the base case is correct, then write down---with quantifiers---exactly the proposition that the induction step is meant to prove. Explain why the argument in the induction step failed to prove this proposition.
 \end{exercise}
 
@@ -212,7 +213,6 @@ We may have spotted the error in what was to come.
 What follows are a couple more examples of proofs by weak induction.
 
 \begin{proposition}
-\plan{4.1}{Aanbevolen}
 For all $n \in \mathbb{N}$, we have $\displaystyle \sum_{k=0}^n k^3 = \left( \sum_{k=0}^n k \right)^2$.
 \end{proposition}
 
@@ -270,6 +270,7 @@ By induction, the result follows.
 The following exercises generalises \Cref{exSumOfPowersOf2} to prove the correctness of a formula for the sum of a \textit{geometric progression} of real numbers.
 
 \begin{exercise}
+\plan{4.1}{Essentieel}
 \label{exFormulaForGeometricProgression}
 Let $a,r \in \mathbb{R}$ with $r \ne 1$. Then
 \[ \sum_{k=0}^n ar^k = \frac{a(1-r^{n+1})}{1-r} \]
@@ -279,7 +280,6 @@ for all $n \in \mathbb{N}$.
 So far in this section most of the results that we have proved by induction have concerned numbers, and particularly identities involving natural numbers. But the scope of proof by induction is not limited to such results---the next exercise, for example, concerns sets and bijections.
 
 \begin{exercise}
-\plan{4.1}{Essentieel}
 Let $n \in \mathbb{N}$ and for each $k \in [n+1]$ let $X_k$ be a set. Prove by induction on $n$ that there is a bijection $\displaystyle \prod_{k \in [n+1]} X_k \to \left( \prod_{k \in [n]} X_k \right) \times X_n$.
 \hintlabel{exProductOfSuccNSets}{%
 To define the bijection, think about what the elements of the two sets look like: The elements of $\prod_{k \in [n+1]} X_k$ look like $(a_0, a_1, \dots, a_{n-1}, a_n)$, where $a_k \in X_k$ for each $k \in [n+1]$. On the other hand, the elements of $\left( \prod_{k \in [n]} X_k \right) \times X_n$ look like $((a_0, a_1, \dots, a_{n-1}), a_n)$.
@@ -417,13 +417,13 @@ Indeed:
 \end{example}
 
 \begin{exercise}
+\plan{4.1}{Aanbevolen}
 Prove that $\dbinom{n}{k} = \dbinom{n}{n-k}$ for all $n,k \in \mathbb{N}$ with $k \le n$.
 \end{exercise}
 
 A very useful application of binomial coefficients in elementary algebra is to the binomial theorem.
 
 \begin{theorem}[Binomial theorem]
-\plan{4.1}{Aanbevolen}
 \label{thmBinomialTheorem}
 Let $n \in \mathbb{N}$ and $x,y \in \mathbb{R}$. Then
 \[ (x+y)^n = \sum_{k=0}^n \binom{n}{k} x^k y^{n-k} \]
@@ -478,6 +478,7 @@ Both of these identities can be proved much more elegantly, quickly and easily u
 \end{example}
 
 \begin{exercise}
+\plan{4.1}{Aanbevolen}
 Use the binomial theorem to prove that
 \[ \sum_{i=0}^n (-1)^i \binom{n}{i} = 0 \]
 \hintlabel{exAlternatingSumOfBinomialCoefficientsIsZero}{%

--- a/book/mathematical-induction/weak-induction.tex
+++ b/book/mathematical-induction/weak-induction.tex
@@ -145,6 +145,7 @@ Prove by induction that $\displaystyle \sum_{k=0}^n 2^k = 2^{n+1} - 1$ for all $
 The following proposition has a proof by induction in which the base case is not zero.
 
 \begin{proposition}
+\plan{4.1}{Essentieel}
 \label{propWeakInductionNonzeroBaseCaseExample}
 For all $n \ge 4$, we have $3n < 2^n$.
 \end{proposition}
@@ -211,6 +212,7 @@ We may have spotted the error in what was to come.
 What follows are a couple more examples of proofs by weak induction.
 
 \begin{proposition}
+\plan{4.1}{Aanbevolen}
 For all $n \in \mathbb{N}$, we have $\displaystyle \sum_{k=0}^n k^3 = \left( \sum_{k=0}^n k \right)^2$.
 \end{proposition}
 
@@ -277,6 +279,7 @@ for all $n \in \mathbb{N}$.
 So far in this section most of the results that we have proved by induction have concerned numbers, and particularly identities involving natural numbers. But the scope of proof by induction is not limited to such results---the next exercise, for example, concerns sets and bijections.
 
 \begin{exercise}
+\plan{4.1}{Essentieel}
 Let $n \in \mathbb{N}$ and for each $k \in [n+1]$ let $X_k$ be a set. Prove by induction on $n$ that there is a bijection $\displaystyle \prod_{k \in [n+1]} X_k \to \left( \prod_{k \in [n]} X_k \right) \times X_n$.
 \hintlabel{exProductOfSuccNSets}{%
 To define the bijection, think about what the elements of the two sets look like: The elements of $\prod_{k \in [n+1]} X_k$ look like $(a_0, a_1, \dots, a_{n-1}, a_n)$, where $a_k \in X_k$ for each $k \in [n+1]$. On the other hand, the elements of $\left( \prod_{k \in [n]} X_k \right) \times X_n$ look like $((a_0, a_1, \dots, a_{n-1}), a_n)$.
@@ -420,6 +423,7 @@ Prove that $\dbinom{n}{k} = \dbinom{n}{n-k}$ for all $n,k \in \mathbb{N}$ with $
 A very useful application of binomial coefficients in elementary algebra is to the binomial theorem.
 
 \begin{theorem}[Binomial theorem]
+\plan{4.1}{Aanbevolen}
 \label{thmBinomialTheorem}
 Let $n \in \mathbb{N}$ and $x,y \in \mathbb{R}$. Then
 \[ (x+y)^n = \sum_{k=0}^n \binom{n}{k} x^k y^{n-k} \]

--- a/book/miscellany/limits-of-functions.tex
+++ b/book/miscellany/limits-of-functions.tex
@@ -41,6 +41,7 @@ Given $a \in \mathbb{R}$, if $a>1$, then letting $\delta = 1-a > 0$ reveals that
 \end{example}
 
 \begin{exercise}
+\plan{6.2}{Essentieel}
 Let $a,b \in \mathbb{R}$ with $a<b$. Prove that $\overline{(a,b)} = \overline{(a,b]} = \overline{[a,b)} = [a,b]$.
 \end{exercise}
 
@@ -76,22 +77,27 @@ Let $f : D \to \mathbb{R}$ be a function, let $a \in D$, and $\ell_1, \ell_2 \in
 \end{exercise}
 
 \begin{exercise}
+\plan{6.2}{Essentieel}
 Define $f: \mathbb{R} \to \mathbb{R}$ by $f(x) = 2x - 3$ for all $x \in \mathbb{R}$. Prove using the $\varepsilon$-$\delta$ definition that $f(x) \to 1$ as $x \to 2$.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.2}{Essentieel}
 Define $f: \mathbb{R} \to \mathbb{R}$ by $f(x) = 3x + 1$ for all $x \in \mathbb{R}$. Prove using the $\varepsilon$-$\delta$ definition that $f(x) \to 10$ as $x \to 3$.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.2}{Essentieel}
 Define $f: \mathbb{R} \to \mathbb{R}$ by $f(x) = x^2 - 3x + 1$ for all $x \in \mathbb{R}$. Prove using the $\varepsilon$-$\delta$ definition that $f(x) \to 5$ as $x \to 4$.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.2}{Essentieel}
 Define $f: \mathbb{R} \to \mathbb{R}$ by $f(x) = \frac{2x + 1}{4x - 2}$ for all $x \in \mathbb{R}$. Prove using the $\varepsilon$-$\delta$ definition that $f(x) \to \frac{3}{2}$ as $x \to 1$.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.2}{Essentieel}
 Define $f: \mathbb{R} \to \mathbb{R}$ by $f(x) = \frac{x^2 + 2x - 3}{x^2 - 1}$ for all $x \in \mathbb{R}$. Prove using the $\varepsilon$-$\delta$ definition that $f(x) \to 2$ as $x \to 1$.
 \end{exercise}
 

--- a/book/number-theory/modular-arithmetic.tex
+++ b/book/number-theory/modular-arithmetic.tex
@@ -117,23 +117,27 @@ So the integers $x$ for which $3x-5$ and $2x+3$ leave the same remainder when di
 \end{example}
 
 \begin{exercise}
+\plan{5.2}{Essentieel}
 For which integers $x$ does the congruence $5x+1 \equiv x+8 \cmod{3}$ hold? Characterise such integers $x$ in terms of their remainder when divided by $3$.
 \end{exercise}
 
 So far this all feels like we haven't done very much: we've just introduced a new symbol $\equiv$ which behaves just like equality\dots but does it really? The following exercises should expose some more ways in which congruence \textit{does} behave like equality, and some in which it \textit{doesn't}.
 
 \begin{exercise}
+\plan{5.2}{Essentieel}
 Fix a modulus $n$. Is it true that
 \[ a \equiv b \cmod{n} \quad \Rightarrow \quad a^k \equiv b^k \cmod{n} \] for all $a,b \in \mathbb{Z}$ and $k \in \mathbb{N}$? If so, prove it; if not, provide a counterexample.
 \end{exercise}
 
 \begin{exercise}
+\plan{5.2}{Essentieel}
 Fix a modulus $n$. Is it true that
 \[ k \equiv \ell \cmod{n} \quad \Rightarrow \quad a^k \equiv a^{\ell} \cmod{n} \]
 for all $k,\ell \in \mathbb{N}$ and $a \in \mathbb{Z}$? If so, prove it; if not, provide a counterexample.
 \end{exercise}
 
 \begin{exercise}
+\plan{5.2}{Essentieel}
 Fix a modulus $n$. Is it true that
 \[ qa \equiv qb \cmod{n} \quad \Rightarrow \quad a \equiv b \cmod{n} \]
 for all $a,b,q \in \mathbb{Z}$ with $q \not \equiv 0 \cmod{n}$? If so, prove it; if not, provide a counterexample.

--- a/book/number-theory/q.tex
+++ b/book/number-theory/q.tex
@@ -125,6 +125,7 @@ Every integer is congruent modulo $7$ to its remainder when divided by $21$.
 \end{chapex}
 
 \begin{chapex} % Never
+\chplan{5.2}{Aanbevolen}
 \label{cqNumberTheoryTFEnd}
 Let $k \ge 1$. Then $15^k \equiv 1 \cmod{6}$.
 \end{chapex}

--- a/book/real-numbers/completeness-convergence.tex
+++ b/book/real-numbers/completeness-convergence.tex
@@ -31,6 +31,7 @@ Hence $1$ is indeed a supremum of $(0,1)$.
 \end{example}
 
 \begin{exercise}
+\plan{6.1}{Aanbevolen}
 \label{exDefineLowerBoundInfimum}
 \index{lower bound!of subset of $\mathbb{R}$}
 \index{infimum!of subset of $\mathbb{R}$}
@@ -272,26 +273,32 @@ Thus, as claimed, we have $|r_n-2|<\varepsilon$ for all $n \ge N$. It follows th
 \end{example}
 
 \begin{exercise}
+\plan{6.1}{Aanbevolen}
 Let $(x_n)$ be the constant sequence with value $a \in \mathbb{R}$. Prove that $(x_n) \to a$.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.1}{Essentieel}
 Determine the limit of the sequence $(a_n)$ defined by $a_n=\frac{1}{n^2}$. Then prove it using the $\epsilon$-$N$ definition.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.1}{Essentieel}
 Determine the limit of the sequence $(b_n)$ defined by $b_n=\frac{3n}{2n+1}$. Then prove it using the $\epsilon$-$N$ definition.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.1}{Essentieel}
 Determine the limit of the sequence $(c_n)$ defined by $c_n=3+\frac{n-1}{2n+1}$. Then prove it using the $\epsilon$-$N$ definition.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.1}{Essentieel}
 Determine the limit of the sequence $(d_n)$ defined by $d_n=\frac{1}{2^n}$. Then prove it using the $\epsilon$-$N$ definition.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.1}{Essentieel}
 Determine the limit of the sequence $(z_n)$ defined by $z_n=\frac{n+1}{n+2}$. Then prove it using the $\epsilon$-$N$ definition.
 \end{exercise}
 
@@ -350,12 +357,14 @@ In both cases, we've found $n \ge N$ such that $|x_n-a| \ge 1$. It follows that 
 \Cref{exSequencePlusMinusOneDiverges} is an example of a \textit{periodic} sequence---that is, it's a sequence that repeats itself. It is difficult for such sequences to converge since, intuitively speaking, they jump up and down a lot. (In fact, the only way that a period sequence \textit{can} converge is if it is a constant sequence!)
 
 \begin{exercise}
+\plan{6.1}{Essentieel}
 Let $(y_n)$ be the sequence defined by $y_n=n$ for all $n \in \mathbb{N}$:
 \[ (0,1,2,3,\dots) \]
 Prove that $(y_n)$ diverges.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.1}{Essentieel}
 Let $r \in \mathbb{R}$. Recall that $(r^n) \to 0$ if $|r|<1$ (this was \Cref{propPowerOfRTendsToZero}) and that $(r^n)$ diverges if $r=-1$ (this was \Cref{exSequencePlusMinusOneDiverges}). Prove that $(r^n)$ diverges if $|r|>1$.
 \end{exercise}
 
@@ -520,6 +529,7 @@ Hence $(x_ny_n) \to ab$, as required.
 \end{cproof}
 
 \begin{exercise}
+\plan{6.1}{Aanbevolen}
 Prove parts (b) and (d) of \Cref{thmLimitsPreserveArithmeticOperations}.
 \end{exercise}
 
@@ -539,6 +549,7 @@ as required.
 \end{example}
 
 \begin{exercise}
+\plan{6.1}{Bonus}
 \label{exPolynomialsAreContinuousUsingSequences}
 Let $(x_n)$ be a sequence of real numbers converging to a real number $a$, and let $p(x) = a_0 + a_1x + \cdots + a_d x^d$ be a polynomial function. Prove that $(p(x_n)) \to p(a)$, and that $\left( \frac{1}{p(x_n)} \right) \to \frac{1}{p(a)}$ if $p(a) \ne 0$.
 \end{exercise}

--- a/book/real-numbers/series-sums.tex
+++ b/book/real-numbers/series-sums.tex
@@ -54,6 +54,7 @@ It follows that $S = \displaystyle \lim_{N \to \infty} (s_N) = 2$, as required.
 \end{example}
 
 \begin{exercise}
+\plan{6.2}{Aanbevolen}
 Prove that the series $\displaystyle \sum_{n \ge 3} \dbinom{n}{3}^{-1}$ converges, and find its sum.
 \hintlabel{exSumOfReciprocalsOfNChoose3}{%
 Begin by observing that $\displaystyle \dbinom{n}{3}^{-1} = \dfrac{3}{n-2} - \dfrac{6}{n-1} + \dfrac{3}{n}$.
@@ -68,6 +69,7 @@ Thus the sequence of partial sums is unbounded, so does not converge to a real n
 \end{example}
 
 \begin{exercise}
+\plan{6.2}{Essentieel}
 \label{exAlternatingSeriesOfOneDiverges}
 Prove that the series $\sum_{n \ge 0} (-1)^n$ diverges.
 \end{exercise}
@@ -96,10 +98,12 @@ as claimed.
 \end{cproof}
 
 \begin{exercise}
+\plan{6.2}{Essentieel}
 Prove that the series $\displaystyle \sum_{n \ge 0} r^n$ diverges for all $r \in \mathbb{R} \setminus (-1,1)$.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.2}{Essentieel}
 \solution{exSumOfReciprocalsOfPowersOfTwo}{(b): The correct formula for the $N^{\text{th}}$ partial sum is $\displaystyle s_N = 1 - \frac{1}{2^N}$.}
 Consider the series $\displaystyle \sum_{k\geq1}^{} \frac{1}{2^k}$.
 \begin{enumerate}[(a)]
@@ -111,6 +115,7 @@ Consider the series $\displaystyle \sum_{k\geq1}^{} \frac{1}{2^k}$.
 \end{exercise}
 
 \begin{exercise}
+\plan{6.2}{Essentieel}
     
 Consider the series $\displaystyle \sum_{k\geq1}^{} \frac{2}{k^2+k}$.
 \begin{enumerate}[(a)]
@@ -145,6 +150,7 @@ as required.
 \end{cproof}
 
 \begin{exercise}
+\plan{6.2}{Aanbevolen}
 Prove part (b) of \Cref{thmLinearityOfSummation}, and deduce that if $\displaystyle \sum_{n \ge 0} a_n$ and $\displaystyle \sum_{n \ge 0} b_n$ are convergent series, then $\displaystyle \sum_{n \ge 0} (a_n - b_n)$ converges, and its sum is equal to $\displaystyle \sum_{n \ge 0} a_n - \sum_{n \ge 0} b_n$.
 \end{exercise}
 

--- a/book/relations/equivalence-relations.tex
+++ b/book/relations/equivalence-relations.tex
@@ -27,6 +27,7 @@ Let $R$ be the relation on $\mathbb{R}$ defined for $a,b \in \mathbb{R}$ by $a \
 \end{example}
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 \label{exEquivalenceRelationFromFunction}
 Given a function $f : X \to Y$, define a relation $\sim_f$ on $X$ by
 \[ a \sim_f b \quad \Leftrightarrow \quad f(a) = f(b) \]
@@ -36,6 +37,7 @@ for all $a,b \in X$. Prove that $\sim_f$ is an equivalence relation on $X$.
 The equivalence relation in the next exercise comes back with a vengeance in \Cref{secCardinality}, where we will use it to compare the sizes of (finite and) infinite sets.
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 \label{exBijectionIsEquivalenceRelation}
 Let $\mathcal{S}$ be some set whose elements are all sets. (For example, we could take $\mathcal{S} = \mathcal{P}(X)$ for some fixed set $X$.) Define a relation $\cong$ \inlatex{cong}\lindexmmc{cong}{$\cong$} on $\mathcal{S}$ by letting $U \cong V$ if and only if there exists a bijection $f : U \to V$, for all $U,V \in \mathcal{S}$. Prove that $\cong$ is an equivalence relation on $\mathcal{S}$.
 \end{exercise}
@@ -80,6 +82,7 @@ Let $n \in \mathbb{Z}$. Prove that if $n \ne 0$, then $a \equiv b \cmod{n}$ if a
 \end{exercise}
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 Let $a,b \in \mathbb{Z}$. When is it true that $a \equiv b \cmod{0}$? When is it true that $a \equiv b \cmod{1}$?
 \end{exercise}
 
@@ -116,6 +119,7 @@ For example, suppose $a$ and $b$ are two very large natural numbers, each with s
 To make this precise, we introduce the notion of an \textit{equivalence class}. For a set $X$ with an equivalence relation, the equivalence class of an element $a \in X$ will be the set of elements of $X$ that $a$ is equivalent to. By working with the \textit{equivalence classes} of elements of $X$, rather than the elements of $X$ themselves, we are able to regard two equivalent elements as being `the same'.
 
 \begin{definition}
+\plan{5.1}{Aanbevolen}
 \index{equivalence class}
 \index{quotient!of a set by an equivalence relation}
 Let $X$ be a set and let $\sim$ be an equivalence relation on $X$. The $\sim$-\textbf{equivalence class} of an element $a \in X$ is the set $[a]_{\sim}$ \inlatexnb{[x]\_\{\textbackslash{}sim\}} defined by
@@ -159,6 +163,7 @@ Thus we have $[a]_{\sim_f} = f^{-1}[\{ f(a) \}]$.
 \end{example}
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 Let $f : X \to Y$ be a function. Prove that $f$ is injective if and only if each $\sim_f$-equivalence class has a unique element, where $\sim_f$ is the equivalence relation defined in \Cref{exEquivalenceRelationFromFunction}.
 \end{exercise}
 
@@ -202,6 +207,7 @@ So $a \sim b$ if and only if $[a]_{\sim} = [b]_{\sim}$.
 For congruence, special terminology and notation exists for equivalence classes and quotients.
 
 \begin{definition}
+\plan{5.1}{Aanbevolen}
 \label{defCongruenceClass}
 \index{congruence class}
 \nindex{an}{$[a]_n$}{congruence class}
@@ -265,6 +271,7 @@ Let $E$ be the set of all even integers and $O$ be the set of all odd integers. 
 \end{example}
 
 \begin{example}
+\plan{5.1}{Essentieel}
 \label{exPartitionOfNIntoPairs}
 Let $\mathcal{A} = \{ \{ 2n, 2n+1 \} \mid n \in \mathbb{N} \}$. Then $\mathcal{A}$ is a partition of $\mathbb{N}$:
 \begin{itemize}
@@ -332,6 +339,7 @@ So ${\sim} = {\approx}$.
 \end{cproof}
 
 \begin{exercise}
+\plan{5.2}{Essentieel}
 \label{exQuotientIsPartition}
 Prove part (a) of \Cref{thmEquivalenceRelationsPartitions}.
 \end{exercise}
@@ -341,6 +349,7 @@ Prove part (a) of \Cref{thmEquivalenceRelationsPartitions}.
 defined by $\mathcal{Q}(\sim)=X/{\sim}$ for all equivalence relations $\sim$ on $X$, is a bijection. Well-definedness of $\mathcal{Q}$ is ensured by part (a) of \Cref{thmEquivalenceRelationsPartitions}, and the fact that $\mathcal{Q}$ is a bijection is ensured by part (b).
 
 \begin{exercise}
+\plan{5.2}{Aanbevolen}
 For each $i \in [0,1)$ let $A_i = \{ i+n \mid n \in \mathbb{Z} \} \subseteq \mathbb{R}$, and define $\mathcal{A} = \{ A_i \mid i \in [0,1) \}$.
 
 Prove that $\mathcal{A}$ is a partition of $\mathbb{R}$, and provide an explicit description of the (unique!) equivalence relation $\sim$ on $\mathbb{R}$ such that $\mathbb{R}/{\sim} = \mathcal{A}$.
@@ -389,6 +398,7 @@ So $k$ is an inverse for $h$, as required.
 \end{cproof}
 
 \begin{exercise}
+\plan{5.2}{Essentieel}
 \label{exBijectionOfQuotientsAndClassesInducesBijectionOfSets}
 Let $X$ and $Y$ be sets, let $\sim$ be an equivalence relation on $X$ and let $\approx$ be an equivalence relation on $Y$. Assume that there is a bijection $p : X/{\sim} \to Y/{\approx}$, and for each equivalence class $E \in X/{\sim}$ there is a bijection $h_E : E \to p(E)$. Use \Cref{lemBijectionBetweenPartitionAndComponentsInducesBijectionOfSets} to prove that there is a bijection $h : X \to Y$.
 \end{exercise}
@@ -398,6 +408,7 @@ Let $X$ and $Y$ be sets, let $\sim$ be an equivalence relation on $X$ and let $\
 We will now show that equivalence relations on a set $X$ are essentially the same thing as \textit{surjections} from $X$ to another set.
 
 \begin{definition}
+\plan{5.2}{Aanbevolen}
 \label{defQuotientFunction}
 \index{function!quotient}
 \index{quotient function}
@@ -409,6 +420,7 @@ Recall that, given $a \in \mathbb{Z}$, we have $[a]_2 = [0]_2$ if $a$ is even, a
 \end{example}
 
 \begin{exercise}
+\plan{5.2}{Aanbevolen}
 Let $n \in \mathbb{Z}$ with $n \ne 0$. Describe the quotient function $q_n : \mathbb{Z} \to \mathbb{Z}/n\mathbb{Z}$ in terms of remainders.
 \end{exercise}
 
@@ -473,6 +485,7 @@ In light of \Cref{thmEquivalenceRelationsSurjections}, we have now established t
 \end{center}
 
 \begin{exercise}
+\plan{5.2}{Essentieel}
 Give an explicit description of the dashed arrow in the above diagram. That is, describe the correspondence between partitions of a set $X$ and surjections whose domain is $X$.
 \hintlabel{exPartitionsSurjections}{%
 Given a partition $\mathcal{U}$ of a set $X$, find a surjection $q : X \to \mathcal{U}$. Then prove that, for every surjection $p : X \to A$, there is a unique partition $\mathcal{U}_p$ of $X$ and a unique bijection $f : \mathcal{U}_p \to A$ such that, for all $U \in \mathcal{U}_p$, we have $p(x) = f(U)$ for all $x \in U$. The structure of the proof will be similar to that of \Cref{thmEquivalenceRelationsSurjections}.

--- a/book/relations/q.tex
+++ b/book/relations/q.tex
@@ -126,6 +126,7 @@ Every relation that is not symmetric is antisymmetric.
 \end{chapex}
 
 \begin{chapex} % False
+\chplan{5.1}{Essentieel}
 Every symmetric, antisymmetric relation is reflexive.
 \end{chapex}
 
@@ -147,11 +148,13 @@ For all sets $X$, the graph of a relation on $X$ is the graph of a function $X \
 \asnquestiontext{cqRelationsASNBegin}{cqRelationsASNEnd}
 
 \begin{chapex} % Sometimes
+\chplan{5.2}{Essentieel}
 \label{cqRelationsASNBegin}
 Let $\sim$ be an equivalence relation on a set $X$. Then the relation $\approx$ on $\mathcal{P}(X) \setminus \{ \varnothing \}$, defined by $A \approx B$ if and only if $x \sim y$ for all $x \in A$ and $y \in B$, is an equivalence relation.
 \end{chapex}
 
 \begin{chapex} % Always
+\chplan{5.2}{Essentieel}
 \label{cqRelationsASNEnd}
 Let $\sim$ be an equivalence relation on a set $X$. Then the relation $\approx$ on $\mathcal{P}(X) \setminus \{ \varnothing \}$, defined by $A \approx B$ if and only if $x \sim y$ for some $x \in A$ and $y \in B$, is an equivalence relation.
 \end{chapex}

--- a/book/relations/relations.tex
+++ b/book/relations/relations.tex
@@ -55,6 +55,7 @@ Recall the relation $R$ on $\mathbb{R}$ that we defined above for $a,b \in \math
 \end{example}
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 Let $R$ and $S$ be relations on $\mathbb{R}$ defined for $a,b \in \mathbb{R}$ by letting
 \[ a \mathrel{R} b ~ \Leftrightarrow ~ b-a \in \mathbb{Q} \quad \text{and} \quad a \mathrel{S} b ~ \Leftrightarrow ~ \exists n \in \mathbb{Z},~ (n \ne 0) \wedge n(b-a) \in \mathbb{Z} \]
 Prove that $R=S$.
@@ -97,10 +98,12 @@ Note that $\mathrm{Gr}(C)$ is \textit{not} the graph of a function $f : [0,1] \t
 \end{example}
 
 \begin{exercise}
+\plan{5.1}{Aanbevolen}
 Let $R$ be the relation on $\mathbb{Z}$ defined for $x,y \in \mathbb{Z}$ by letting $x \mathrel{R} y$ if and only if $x^2=y^2$. Describe its graph $\mathrm{Gr}(R) \subseteq \mathbb{Z} \times \mathbb{Z}$.
 \end{exercise}
 
 \begin{exercise}
+\plan{5.1}{Aanbevolen}
 Let $f : X \to Y$ be a function, and define the relation $R_f$ from $X$ to $Y$ as in \Cref{exRelationExamples}. Prove that $\mathrm{Gr}(R_f) = \mathrm{Gr}(f)$---that is, the graph of the \textit{relation} $R_f$ is equal to the graph of the \textit{function} $f$.
 \end{exercise}
 
@@ -117,6 +120,7 @@ The \textbf{empty relation} from a set $X$ to a set $Y$ is the relation $\varnot
 \end{definition}
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 \label{exGraphOfEmptyAndDiscreteRelations}
 Let $X$ and $Y$ be sets. Describe the graphs $\mathrm{Gr}(D_{X,Y})$ and $\mathrm{Gr}(\varnothing_{X,Y})$.
 \end{exercise}
@@ -161,6 +165,7 @@ Let $X$ be a set. The \textbf{diagonal subset} of $X \times X$ is the set $\Delt
 To see why $\Delta_X$ is called the `diagonal' subset, try plotting $\Delta_{\mathbb{R}} \subseteq \mathbb{R} \times \mathbb{R}$ on a standard pair of axes (like in \Cref{exCircleRelation}).
 
 \begin{exercise}
+\plan{5.1}{Aanbevolen}
 Let $X$ be a set. Prove that $\Delta_X = \mathrm{Gr}(=)$.
 \end{exercise}
 
@@ -208,11 +213,13 @@ Let $R$ be the relation on $\mathbb{R}$ defined for $a,b \in \mathbb{R}$ by $a \
 \end{example}
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 \label{exSubsetIsReflexive}
 Let $X$ be a set. Prove that $\subseteq$ is a reflexive relation on $\mathcal{P}(X)$, but $\subsetneqq$ is not.
 \end{exercise}
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 \label{exDivisibilityIsReflexive}
 Prove that the relation `$x$ divides $y$' on $\mathbb{Z}$ is reflexive.
 \end{exercise}
@@ -220,6 +227,7 @@ Prove that the relation `$x$ divides $y$' on $\mathbb{Z}$ is reflexive.
 The next exercise demonstrates that when determining if a relation is reflexive, we must be careful to specify its domain.
 
 \begin{exercise}
+\plan{5.1}{Aanbevolen}
 \label{exReflexivitySensitiveToDomainOfRelation}
 Let $G = \{ (0,0), (1,1), (2,2) \}$. Let $R$ be the relation on $[3]$ whose graph is $G$, and let $S$ be the relation on $[4]$ whose graph is $G$. Prove that $R$ is reflexive, but $S$ is not.
 \end{exercise}
@@ -257,12 +265,14 @@ so that $a-b \in \mathbb{Q}$. Hence $b \mathrel{R} a$, as required.
 \end{example}
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 Find all subsets $U \subseteq \mathbb{Z}$ such that the relation `$x$ divides $y$' on $U$ is symmetric.
 \end{exercise}
 
 We showed in \Cref{exReflexivitySensitiveToDomainOfRelation} that reflexivity of a relation is sensitive to its domain. The next exercise demonstrates that symmetry is \textit{not} sensitive to the domain---that is, it is an \textit{intrinsic} property of the relation.
 
 \begin{exercise}
+\plan{5.1}{Aanbevolen}
 \label{exSymmetryNotSensitiveToDomainOfRelation}
 Let $R$ and $S$ be relations such that $\mathrm{Gr}(R) = \mathrm{Gr}(S)$. Note that the domain of $R$ might be different from the domain of $S$. Prove that $R$ is symmetric if and only if $S$ is symmetric.
 \end{exercise}
@@ -297,11 +307,13 @@ The order relation $\le$ on $\mathbb{R}$ is antisymmetric, since for all $a,b \i
 \end{example}
 
 \begin{exercise}
+\plan{5.1}{Aanbevolen}
 \label{exDivisibilityIsOrIsNotAntisymmetric}
 Prove that the relation `$x$ divides $y$' on $\mathbb{N}$ is antisymmetric, but not on $\mathbb{Z}$.
 \end{exercise}
 
 \begin{exercise}
+\plan{5.1}{Aanbevolen}
 Let $X$ be a set. Prove that $\subseteq$ is an antisymmetric relation on $\mathcal{P}(X)$.
 \end{exercise}
 
@@ -346,10 +358,12 @@ so that $c-a \in \mathbb{Q}$. Hence $a \mathrel{R} c$, as required.
 \end{example}
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 Let $X$ be a set. Prove that $\subseteq$ is a transitive relation on $\mathcal{P}(X)$.
 \end{exercise}
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 \label{exDivisibilityIsTransitive}
 Prove that the relation `$x$ divides $y$' on $\mathbb{Z}$ is transitive.
 \end{exercise}
@@ -357,6 +371,7 @@ Prove that the relation `$x$ divides $y$' on $\mathbb{Z}$ is transitive.
 Like symmetry, transitive is an intrinsic property of relations---that is, transitivity is not sensitive to the domain of the relation---as the next exercise demonstrates.
 
 \begin{exercise}
+\plan{5.1}{Essentieel}
 \label{exTransitivityNotSensitiveToDomainOfRelation}
 Let $R$ and $S$ be relations such that $\mathrm{Gr}(R) = \mathrm{Gr}(S)$. Note that the domain of $R$ might be different from the domain of $S$. Prove that $R$ is transitive if and only if $S$ is transitive.
 \end{exercise}

--- a/book/sets/q.tex
+++ b/book/sets/q.tex
@@ -20,10 +20,12 @@ Express the set $\mathcal{P}(\{ \varnothing, \{ \varnothing, \{ \varnothing \} \
 \end{chapex}
 
 \begin{chapex}
+\chplan{2.2}{Aanbevolen}
 Let $X$ be a set and let $U, V \subseteq X$. Prove that $U$ and $V$ are disjoint if and only if $U \subseteq X \setminus V$.
 \end{chapex}
 
 \begin{chapex}
+\chplan{2.2}{Aanbevolen}
 For each of the following statements, determine whether or not it is true for all sets $A$ and $X$, and prove your claim.
 \begin{multicols}{2}
 \begin{enumerate}[(a)]
@@ -36,6 +38,7 @@ For each of the following statements, determine whether or not it is true for al
 \end{chapex}
 
 \begin{chapex}
+\chplan{2.2}{Essentieel}
 \label{cqPowerSetRespectSetOperations}
 For each of the following statements, determine whether it is true for all sets $X,Y$, false for all sets $X,Y$, or true for some choices of $X$ and $Y$ and false for others.
 \begin{multicols}{2}
@@ -103,6 +106,7 @@ A subset $U \subseteq \mathbb{R}$ is \textbf{open} if, for all $a \in U$, there 
 In Questions \Crefrange{cqOpenSubsetsOfRBegin}{cqOpenSubsetsOfREnd} you will prove some elementary facts about open subsets of $\mathbb{R}$.
 
 \begin{chapex}
+\chplan{2.2}{Aanbevolen}
 \label{cqOpenSubsetsOfRBegin}
 For each of the following subsets of $\mathbb{R}$, determine (with proof) whether it is open:
 \begin{multicols}{3}
@@ -122,6 +126,7 @@ Prove that a subset $U \subseteq \mathbb{R}$ is open if and only if, for all $a 
 \end{chapex}
 
 \begin{chapex}
+\chplan{2.2}{Bonus}
 In this question you will prove that the intersection of finitely many open sets is open, but the intersection of infinitely many open sets might not be open.
 \begin{enumerate}[(a)]
 \item Let $n \ge 1$ and suppose $U_1, U_2, \dots, U_n$ are open subsets of $\mathbb{R}$. Prove that the intersection $U_1 \cap U_2 \cap \cdots \cap U_n$ is open.
@@ -178,6 +183,7 @@ Let $a$ and $b$ be arbitrary objects. Then $\{ a, b \} = \{ b, a \}$.
 \end{chapex}
 
 \begin{chapex} % Sometimes
+\chplan{2.1}{Aanbevolen}
 Let $a$, $b$ and $c$ be arbitrary objects. Then $\{ a, b \} = \{ a, c \}$.
 \end{chapex}
 
@@ -194,10 +200,12 @@ Let $X$ and $Y$ be sets with $X \ne Y$. Then $\forall a,\, a \in X \Rightarrow a
 \end{chapex}
 
 \begin{chapex} % Always
+\chplan{2.2}{Aanbevolen}
 Let $X$ and $Y$ be sets with $X \cap Y = \varnothing$. Then $\forall a,\, a \in X \Rightarrow a \not\in Y$.
 \end{chapex}
 
 \begin{chapex} % Always
+\chplan{2.1}{Essentieel}
 Let $X$ and $Y$ be sets with $X \ne Y$. Then $\exists a,\, a \in X \wedge a \not\in Y$.
 \end{chapex}
 
@@ -218,6 +226,7 @@ Let $X$ be a set. Then $\{ \varnothing, X \} \subseteq \mathcal{P}(X)$.
 \end{chapex}
 
 \begin{chapex} % Always
+\chplan{2.1}{Essentieel}
 Let $X$ and $Y$ be sets such that $\mathcal{P}(X) = \mathcal{P}(Y)$. Then $X = Y$.
 \end{chapex}
 
@@ -230,6 +239,7 @@ Let $X$, $Y$ and $Z$ be sets such that $X \setminus Y = Z$ and $Y \subseteq Z$. 
 \end{chapex}
 
 \begin{chapex} % Sometimes
+\chplan{2.2}{Aanbevolen}
 Let $X$ and $Y$ be sets. Then $X \cup Y = X \cap Y$.
 \end{chapex}
 

--- a/book/sets/set-operations.tex
+++ b/book/sets/set-operations.tex
@@ -40,15 +40,18 @@ By definition of intersection, we have $x \in [0,\infty) \cap \mathbb{Q}$ if and
 \end{example}
 
 \begin{exercise}
+\plan{2.2}{Essentieel}
 Prove that $[0,\infty) \cap \mathbb{Z} = \mathbb{N}$.
 \end{exercise}
 
 \begin{exercise}
+\plan{2.2}{Aanbevolen}
 Write down the elements of the set
 \[ \{ 0, 1, 4, 7 \} \cap \{ 1, 2, 3, 4, 5 \} \]
 \end{exercise}
 
 \begin{exercise}
+\plan{2.2}{Essentieel}
 Express $[-2,5) \cap [4,7)$ as a single interval.
 \end{exercise}
 
@@ -70,6 +73,7 @@ Conversely, suppose that $X \cap Y = X$. To prove that $X \subseteq Y$, let $a \
 \end{cproof}
 
 \begin{exercise}
+\plan{2.2}{Aanbevolen}
 Let $X$ be a set. Prove that $X \cap \varnothing = \varnothing$.
 \end{exercise}
 
@@ -116,6 +120,7 @@ Formally, the indexing set for this family of sets is the set $I = \{ n \in \mat
 \end{example}
 
 \begin{notation}[Indexed intersection]
+\plan{2.2}{Aanbevolen}
 \label{ntnIntersectionIndexed}
 \index{intersection}
 \index{intersection!indexed}
@@ -193,12 +198,14 @@ Write down the elements of the set
 \end{exercise}
 
 \begin{exercise}
+\plan{2.2}{Essentieel}
 Express $[-2,5) \cup [4,7)$ as a single interval.
 \end{exercise}
 
 The union operation allows us to define the following class of sets that will be particularly useful for us when studying counting principles in \Cref{secCountingPrinciples}.
 
 \begin{exercise}
+\plan{2.2}{Essentieel}
 Let $X$ and $Y$ be sets. Prove that $X \subseteq Y$ if and only if $X \cup Y = Y$.
 \end{exercise}
 
@@ -214,6 +221,7 @@ Let $X,Y,Z$ be sets. We prove that $X \cap (Y \cup Z) = (X \cap Y) \cup (X \cap 
 \end{example}
 
 \begin{exercise}[Distributivity of union over intersection]
+\plan{2.2}{Essentieel}
 \label{exUnionDistributesOverIntersection}
 Let $X,Y,Z$ be sets. Prove that $X \cup (Y \cap Z) = (X \cup Y) \cap (X \cup Z)$.
 \end{exercise}
@@ -235,14 +243,17 @@ Variations of this notation can be understood from context. For example, if the 
 \todo{To do: turn the next exercise into an example}
 
 \begin{exercise}
+\plan{2.2}{Essentieel}
 Express $\displaystyle\bigcup_{n \ge 1} [0,1-\frac{1}{n}]$ as an interval.
 \end{exercise}
 
 \begin{exercise}
+\plan{2.2}{Aanbevolen}
 Prove that $\displaystyle\bigcap_{n \in \mathbb{N}} [n] = \varnothing$ and $\displaystyle\bigcup_{n \in \mathbb{N}} [n] = \mathbb{N}$.
 \end{exercise}
 
 \begin{exercise}
+\plan{2.2}{Essentieel}
 \label{exSubsetsFiniteIntersectionNon-emptyInfiniteIntersectionEmpty}
 Find a family of sets $\{ X_n \mid n \in \mathbb{N} \}$ such that:
 \begin{enumerate}[(i)]
@@ -287,10 +298,12 @@ Write down the elements of the set
 \end{exercise}
 
 \begin{exercise}
+\plan{2.2}{Aanbevolen}
 Express $[-2,5) \setminus [4,7)$ and $[4,7) \setminus [-2,5)$ as intervals.
 \end{exercise}
 
 \begin{exercise}
+\plan{2.2}{Aanbevolen}
 \label{exSetMinusSetMinus}
 Let $X$ and $A$ be sets. Prove that $X \setminus (X \setminus A) = X \cap A$, and deduce that $A \subseteq X$ if and only if $X \setminus (X \setminus A) = A$.
 \end{exercise}
@@ -421,6 +434,7 @@ This is an example of a \textit{graph} of a function. This notion will be define
 \end{example}
 
 \begin{exercise}
+\plan{2.2}{Essentieel}
 Write down the elements of the set $\{ 1, 2 \} \times \{ 3, 4, 5 \}$.
 \end{exercise}
 
@@ -429,6 +443,7 @@ Let $X$ be a set. Prove that $X \times \varnothing = \varnothing$.
 \end{exercise}
 
 \begin{exercise}
+\plan{2.2}{Aanbevolen}
 \label{exCartesianProductNotCommutative}
 Let $X$, $Y$ and $Z$ be sets. Under what conditions is it true that $X \times Y = Y \times X$?
 \end{exercise}

--- a/book/sets/sets.tex
+++ b/book/sets/sets.tex
@@ -147,6 +147,7 @@ so that $[c,d] \subseteq (a,b)$, as required.
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Essentieel}
 Let $a,b,c,d \in \mathbb{R}$ with $a<b$ and $c<d$. Prove that $[a,b) \subseteq (c,d]$ if and only if $a > c$ and $b \le d$.
 \solution{exIntervalContainment}{%
 $(\Rightarrow)$ Assume $[a,b) \subseteq (c,d]$.
@@ -227,6 +228,7 @@ So we must have $a \in [-1,1]$, as required.
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Aanbevolen}
 Prove that $\{ x \in \mathbb{R} \mid x^2 < x \} = (0,1)$.
 \hintlabel{exXSquaredLessThanXAsInterval}{%
 Resist the temptation to draw a graph and claim that you're done: use a proof by double containment, unpacking what it means to be an element of each set using its definition.
@@ -244,6 +246,7 @@ By double containment, we have $A = (0,1)$. \qed
 The set extensionality axiom has the consequence that sets are independent of the order in which their elements appear in list notation, and they are independent of how many times a single element is written---that is, an element of a set is only `counted' once, even if it appears multiple times in list notation. This is illustrated in the following exercise.
 
 \begin{exercise}
+\plan{2.1}{Aanbevolen}
 Prove by double containment that $\{ 0, 1 \} = \{ 1, 0 \}$ and $\{ 0, 0 \} = \{ 0 \}$.
 \hintlabel{exDoubleContainmentListNotation}{%
 If you feel like you're not proving anything, you're probably doing it correctly.
@@ -298,12 +301,14 @@ We observed in \Cref{exBracketN} that the set $[0]$ is empty; here's a more form
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Aanbevolen}
 Let $a,b \in \mathbb{R}$. Prove that $[a,b]$ is empty if and only if $a > b$, and that $(a,b)$ is empty if and only if $a \ge b$.
 \end{exercise}
 
 The next exercise is a logical technicality, which is counterintuitive for the same reason that makes the principle of explosion (\Cref{axPrincipleOfExplosion}) difficult to grasp. However, it is extremely useful for proving facts about the empty set, as we will see soon in \Cref{thmEmptySetIsUnique}.
 
 \begin{exercise}
+\plan{2.1}{Aanbevolen}
 Let $E$ be an empty set and let $p(x)$ be a predicate with one free variable $x$ with domain of discourse $E$. Show that the proposition $\forall x \in E,\, p(x)$ is true, and that the proposition $\exists x \in E,\, p(x)$ is false. What does the proposition $\forall x \in E,\, x \ne x$ mean in English? Is it true?
 \hintlabel{exEverythingIsTrueOfElementsOfEmptySet}{%
 Recall from the beginning of \Cref{secSets} that $\forall x \in X,\, p(x)$ is equivalent to $\forall x,\, (x \in X \Rightarrow p(x))$ and $\exists x \in X,\, p(x)$ is equivalent to $\exists x,\, (x \in X \wedge p(x))$. What can be said about the truth value of $x \in E$ when $E$ is empty?
@@ -335,6 +340,7 @@ The \textbf{empty set} (also known as the \textbf{null set}) is the set with no 
 Some authors write $\{ \}$ instead of $\varnothing$, since $\{ \}$ is simply the empty set expressed in list notation.
 
 \begin{exercise}
+\plan{2.1}{Essentieel}
 \label{exEmptySetSubsetOfEverySet}
 Let $X$ be a set. Prove that $\varnothing \subseteq X$.
 \end{exercise}
@@ -354,10 +360,12 @@ so $\mathcal{P}(X) = \{\varnothing, \{ 1 \}, \{ 2 \}, \{ 1, 2 \}\}$.
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Essentieel}
 Write out the elements of $\mathcal{P}(\{1, 2, 3\})$.
 \end{exercise}
 
 \begin{exercise}
+\plan{2.1}{Aanbevolen}
 Let $X$ be a set. Show that $\varnothing \in \mathcal{P}(X)$ and $X \in \mathcal{P}(X)$.
 \end{exercise}
 
@@ -375,6 +383,7 @@ Assume that $X \subseteq Y$. By the definition of power set (\Cref{defPowerSet})
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Essentieel}
 Let $X$ and $Y$ be sets. Prove that if $X \subseteq Y$, then $\mathcal{P}(X) \subseteq \mathcal{P}(Y)$.
 \end{exercise}
 
@@ -391,6 +400,7 @@ It is true that $\varnothing \subseteq \varnothing$, but false that $\varnothing
 \end{example}
 
 \begin{exercise}
+\plan{2.1}{Aanbevolen}
 Determine, with proof, whether or not each of the following statements is true.
 \begin{enumerate}[(a)]
 \item $\mathcal{P}(\varnothing) \in \mathcal{P}(\mathcal{P}(\varnothing))$;

--- a/planning.py
+++ b/planning.py
@@ -70,5 +70,7 @@ with open('planning_processed.csv', 'w', newline='') as file:
                 lines.append(f"in {section}: {nums}")
             row.append('\n'.join(lines))
         writer.writerow(row)
+    for _ in range(3):
+        writer.writerow(['', '', '', ''])
 
 print("planning_processed.csv has been created successfully!")

--- a/planning.py
+++ b/planning.py
@@ -1,38 +1,74 @@
 import csv
 from collections import defaultdict
 
+
+def parse_section(kind, number):
+    """Return (section_label, exercise_number) for display purposes.
+
+    Exercises:
+      0.x   -> section 'H0',  number x
+      A.B.x -> section 'A.B', number x
+
+    Chapter exercises (chapex):
+      A.x   -> section 'A.E', number x
+    """
+    if kind == 'exercise':
+        if number.startswith('0.'):
+            return ('H0', number[2:])
+        section, _, num = number.rpartition('.')
+        return (section, num)
+    else:  # chapex
+        section, _, num = number.rpartition('.')
+        return (f"{section}.E", num)
+
+
+def section_sort_key(section):
+    """Numerical sort key for section labels like H0, 0.E, 1.1, 1.E, B.3."""
+    if section == 'H0':
+        return (0.0, 0.0)
+    parts = section.split('.')
+    try:
+        first = float(parts[0])
+    except ValueError:
+        # Letters like 'B' sort after numbers
+        first = 1000.0 + ord(parts[0][0])
+    if parts[1] == 'E':
+        second = float('inf')
+    else:
+        second = float(parts[1])
+    return (first, second)
+
+
 # Read the input CSV file
-data = defaultdict(lambda: defaultdict(lambda: {'exercise': [], 'chapex': []}))
+# data[moment][difficulty][section] = [num, ...]
+data = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
 
 with open('planning.csv', 'r') as file:
     reader = csv.reader(file, delimiter=';')
     for row in reader:
         moment, difficulty, kind, number = row
-        data[moment][difficulty][kind].append(number)
+        section, num = parse_section(kind, number)
+        data[moment][difficulty][section].append(num)
 
-# Create a list of all difficulties that occur
-difficulties = sorted({difficulty for moment in data for difficulty in data[moment]})
+# Column order matching target
+DIFFICULTIES = ['Essentieel', 'Aanbevolen', 'Bonus']
 
 # Write the output CSV file
 with open('planning_processed.csv', 'w', newline='') as file:
-    writer = csv.writer(file, delimiter=';')
-    writer.writerow(['Moment'] + difficulties)
+    writer = csv.writer(file, delimiter=',')
+    writer.writerow(['Week'] + DIFFICULTIES)
     for moment in sorted(data.keys()):
         row = [moment]
-        for difficulty in difficulties:
-            content = ""
-            
-            # Add exercises if any exist
-            if data[moment][difficulty]['exercise']:
-                exercises = ','.join(data[moment][difficulty]['exercise'])
-                content += f"Exercises: {exercises}."
-            
-            # Add chapter exercises if any exist
-            if data[moment][difficulty]['chapex']:
-                chapex = ','.join(data[moment][difficulty]['chapex'])
-                content += f"Chapter exercises: {chapex}."
-            row.append(content)
-            
+        for difficulty in DIFFICULTIES:
+            sections = data[moment][difficulty]
+            if not sections:
+                row.append('')
+                continue
+            lines = []
+            for section in sorted(sections.keys(), key=section_sort_key):
+                nums = ', '.join(sections[section])
+                lines.append(f"in {section}: {nums}")
+            row.append('\n'.join(lines))
         writer.writerow(row)
 
 print("planning_processed.csv has been created successfully!")

--- a/test_planning.py
+++ b/test_planning.py
@@ -75,9 +75,44 @@ def test_multiline_cells():
     assert '\n' in cell
 
 
+def test_subparts_exercise():
+    run_script()
+    rows = read_processed()
+    # 1.2.37ab -> in 1.2: ..., 37ab, ...
+    cell = rows['1.2']['Aanbevolen']
+    assert '37ab' in cell, f"Expected '37ab' in 1.2 Aanbevolen, got: {cell!r}"
+
+
+def test_subparts_exercise_multi():
+    run_script()
+    rows = read_processed()
+    # 1.3.44ace -> in 1.3: ..., 44ace, ...
+    cell = rows['2.1']['Essentieel']
+    assert '44ace' in cell, f"Expected '44ace' in 2.1 Essentieel, got: {cell!r}"
+    # 3.1.15abc
+    cell = rows['3.1']['Essentieel']
+    assert '15abc' in cell, f"Expected '15abc' in 3.1 Essentieel, got: {cell!r}"
+    # 3.2.39ab
+    cell = rows['3.2']['Aanbevolen']
+    assert '39ab' in cell, f"Expected '39ab' in 3.2 Aanbevolen, got: {cell!r}"
+
+
+def test_subparts_chapex():
+    run_script()
+    rows = read_processed()
+    # 3.24e and 3.25b (chapex) -> in 3.E: 24e, 25b
+    cell = rows['7.2']['Aanbevolen']
+    assert '24e' in cell, f"Expected '24e' in 7.2 Aanbevolen, got: {cell!r}"
+    assert '25b' in cell, f"Expected '25b' in 7.2 Aanbevolen, got: {cell!r}"
+    # 3.25cd (bonus chapex) -> in 3.E: 25cd
+    cell = rows['7.2']['Bonus']
+    assert '25cd' in cell, f"Expected '25cd' in 7.2 Bonus, got: {cell!r}"
+
+
 if __name__ == '__main__':
     tests = [test_header, test_week_1_1_essentieel, test_week_1_2_essentieel,
-             test_week_7_2_essentieel, test_b_section, test_multiline_cells]
+             test_week_7_2_essentieel, test_b_section, test_multiline_cells,
+             test_subparts_exercise, test_subparts_exercise_multi, test_subparts_chapex]
     failed = 0
     for t in tests:
         try:

--- a/test_planning.py
+++ b/test_planning.py
@@ -1,0 +1,89 @@
+import csv
+import subprocess
+import sys
+
+
+def run_script():
+    result = subprocess.run([sys.executable, 'planning.py'], capture_output=True, text=True)
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+
+
+def read_processed():
+    rows = {}
+    with open('planning_processed.csv', 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows[row['Week']] = row
+    return rows
+
+
+def test_header():
+    run_script()
+    with open('planning_processed.csv', 'r') as f:
+        header = f.readline().strip()
+    assert header == 'Week,Essentieel,Aanbevolen,Bonus', f"Header was: {header!r}"
+
+
+def test_week_1_1_essentieel():
+    run_script()
+    rows = read_processed()
+    cell = rows['1.1']['Essentieel']
+    assert 'in H0:' in cell
+    assert 'in 0.E:' in cell
+    assert 'in 1.1:' in cell
+    assert '0.2' not in cell  # old format gone
+    assert 'Exercises:' not in cell
+    assert 'Chapter exercises:' not in cell
+
+
+def test_week_1_2_essentieel():
+    run_script()
+    rows = read_processed()
+    cell = rows['1.2']['Essentieel']
+    # exercises like 1.1.32 -> in 1.1: 32
+    assert 'in 1.1:' in cell
+    # chapex like 1.1 -> in 1.E: 1
+    assert 'in 1.E:' in cell
+
+
+def test_week_7_2_essentieel():
+    run_script()
+    rows = read_processed()
+    cell = rows['7.2']['Essentieel']
+    # 6.2.22 -> in 6.2: 22
+    assert 'in 6.2:' in cell
+    assert '22' in cell
+    # 10.1.5 -> in 10.1: 5
+    assert 'in 10.1:' in cell
+    # chapex 10.14 -> in 10.E: 14
+    assert 'in 10.E:' in cell
+
+
+def test_b_section():
+    run_script()
+    rows = read_processed()
+    cell = rows['6.2']['Essentieel']
+    # B.3.5 -> in B.3: 5
+    assert 'in B.3:' in cell
+
+
+def test_multiline_cells():
+    run_script()
+    rows = read_processed()
+    # Cells with multiple sections should use newlines
+    cell = rows['1.1']['Essentieel']
+    assert '\n' in cell
+
+
+if __name__ == '__main__':
+    tests = [test_header, test_week_1_1_essentieel, test_week_1_2_essentieel,
+             test_week_7_2_essentieel, test_b_section, test_multiline_cells]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            print(f"FAIL {t.__name__}: {e}")
+            failed += 1
+    sys.exit(failed)


### PR DESCRIPTION
## Summary

- Add `\plan` and `\chplan` LaTeX macros for course planning annotations
- Add Python script (`planning.py`) to process and generate planning data from CSV files
- Add sub-parts support to both macros and match target planning structure
- Reformat `planning_processed.csv` to match `targetplanning.csv` format
- Add tests (`test_planning.py`) covering the planning logic

## Test plan

- [x] Run `python test_planning.py` to verify all planning tests pass
- [ ] Build the LaTeX book to verify `\plan` and `\chplan` macros render correctly
- [ ] Check that planning output matches target planning CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)